### PR TITLE
Fix building with h264 enabled

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -125,7 +125,6 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 #ifdef WITH_H264
 	found = v4l2_find_format(driver_data->video_fd,
-	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
 				 V4L2_PIX_FMT_H264_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 5)) {


### PR DESCRIPTION
It seems there was some error during configuration rework and one line got duplicated somehow. Fix this by removing it.