### PR TITLE
Replace bootlin/libdrm-sun4i dependency with mainline mesa/libdrm

### DIFF
--- a/src/video.c
+++ b/src/video.c
@@ -51,7 +51,7 @@ static struct video_format formats[] = {
 		.v4l2_buffers_count	= 1,
 		.v4l2_mplane		= false,
 		.drm_format		= DRM_FORMAT_NV12,
-		.drm_modifier		= DRM_FORMAT_MOD_ALLWINNER_MB32_TILED,
+		.drm_modifier		= DRM_FORMAT_MOD_ARM_AFBC(1),
 		.planes_count		= 2,
 		.bpp			= 16
 	},


### PR DESCRIPTION
Since libdrm-2.4.95 "Arm AFBC modifiers" was introduced

Replace allwinner specific DRM_FORMAT_MOD_ALLWINNER_MB32_TILED with
DRM_FORMAT_MOD_ARM_AFBC(1)

Signed-off-by: Roman Stratiienko <roman.stratiienko@globallogic.com>