### PR TITLE
[RFC] Patchset to compile for kernel 5.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -55,26 +55,56 @@ AC_CHECK_LIB([m], [sin])
 LIBVA_PACKAGE_VERSION=libva_package_version
 AC_SUBST(LIBVA_PACKAGE_VERSION)
 
-dnl Check for recent enough DRM
+dnl Check for recent DRM headers (libdrm)
 LIBDRM_VERSION=libdrm_version
-PKG_CHECK_MODULES([DRM], [libdrm >= $LIBDRM_VERSION])
+BASE_CFLAGS=$CFLAGS
+PKG_CHECK_MODULES([DRM], [libdrm >= $LIBDRM_VERSION], [CFLAGS="$CFLAGS $DRM_CFLAGS"])
+AC_SUBST(DRM_CFLAGS)
 AC_SUBST(LIBDRM_VERSION)
+
+AC_CHECK_HEADERS([drm_fourcc.h])
+
+AC_MSG_CHECKING([for libdrm supporting DRM_FORMAT_MOD_ALLWINNER_TILED])
+TEST_FOURCC="
+#ifdef HAVE_DRM_FOURCC_H
+#include <drm_fourcc.h>
+#endif
+int main(void) {
+    int test = DRM_FORMAT_MOD_ALLWINNER_TILED;
+    return;
+}
+"
+AS_IF([test "$ac_cv_header_drm_fourcc_h" = "yes"], [
+    AC_COMPILE_IFELSE(
+        [AC_LANG_SOURCE([$TEST_FOURCC])],
+        [RECENT_FOURCC="yes"],
+        [RECENT_FOURCC="no"]
+    )
+    AC_MSG_RESULT([$RECENT_FOURCC])
+])
+
+case "${RECENT_FOURCC}" in
+no)
+	AC_MSG_RESULT("No recent DRM headers support in libdrm. Checking kernel drm header")
+	CFLAGS="$BASE_CFLAGS -I/usr/include/drm/"
+	AC_CHECK_HEADERS([drm_fourcc.h])
+        AS_IF([test "$ac_cv_header_drm_fourcc_h" = "yes"], [
+            AC_COMPILE_IFELSE(
+                [AC_LANG_SOURCE([$TEST_FOURCC])],
+                [RECENT_FOURCC="yes"],
+                [RECENT_FOURCC="no"]
+            )
+            AC_MSG_RESULT([$RECENT_FOURCC])
+        ])
+        ;;
+esac
 
 dnl Check for VA-API
 PKG_CHECK_MODULES(LIBVA_DEPS,     [libva >= va_api_version])
 
 dnl Check for VA/DRM API
 PKG_CHECK_MODULES(LIBVA_DRM_DEPS, [libva-drm],
-  [AC_DEFINE([HAVE_VA_DRM], [1], [Defined to 1 if VA/DRM API is enabled])],
-  [USE_DRM="no"])
-
-# Check for <drm_fourcc.h>
-if test "$USE_DRM" = "yes"; then
-    saved_CPPFLAGS="$CPPFLAGS"
-    CPPFLAGS="$CPPFLAGS $DRM_CFLAGS"
-    AC_CHECK_HEADERS([drm_fourcc.h], [:], [USE_DRM="no"])
-    CPPFLAGS="$saved_CPPFLAGS"
-fi
+  [AC_DEFINE([HAVE_VA_DRM], [1], [Defined to 1 if VA/DRM API is enabled])])
 
 AC_MSG_CHECKING([for MPEG2 support])
 AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
@@ -151,4 +181,4 @@ echo VA-API drivers path .............. : $LIBVA_DRIVERS_PATH
 echo H.264 support .................... : $WITH_H264
 echo H.265 support .................... : $WITH_H265
 echo MPEG2 support .................... : $WITH_MPEG2
-echo
+echo CFLAGS ........................... : $CFLAGS

--- a/src/h264.c
+++ b/src/h264.c
@@ -31,6 +31,7 @@
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
+#include <linux/types.h>
 #include <linux/videodev2.h>
 
 #include "request.h"
@@ -189,7 +190,7 @@ static void h264_fill_dpb(struct request_data *data,
 			continue;
 
 		if (surface)
-			dpb->buf_index = surface->destination_index;
+			dpb->timestamp = surface->destination_index;
 
 		dpb->frame_num = entry->pic.frame_idx;
 		dpb->top_field_order_cnt = entry->pic.TopFieldOrderCnt;

--- a/src/h265.c
+++ b/src/h265.c
@@ -282,7 +282,7 @@ static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
 		if (surface_object == NULL)
 			break;
 
-		slice_params->dpb[i].buffer_index =
+		slice_params->dpb[i].timestamp =
 			surface_object->destination_index;
 
 		if ((hevc_picture->flags & VA_PICTURE_HEVC_RPS_ST_CURR_BEFORE) != 0) {

--- a/src/mpeg2-ctrls.h
+++ b/src/mpeg2-ctrls.h
@@ -1,0 +1,86 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * These are the MPEG2 state controls for use with stateless MPEG-2
+ * codec drivers.
+ *
+ * It turns out that these structs are not stable yet and will undergo
+ * more changes. So keep them private until they are stable and ready to
+ * become part of the official public API.
+ */
+
+#ifndef _MPEG2_CTRLS_H_
+#define _MPEG2_CTRLS_H_
+
+#define V4L2_CID_MPEG_VIDEO_MPEG2_SLICE_PARAMS		(V4L2_CID_MPEG_BASE+250)
+#define V4L2_CID_MPEG_VIDEO_MPEG2_QUANTIZATION		(V4L2_CID_MPEG_BASE+251)
+
+/* enum v4l2_ctrl_type type values */
+#define V4L2_CTRL_TYPE_MPEG2_SLICE_PARAMS 0x0103
+#define	V4L2_CTRL_TYPE_MPEG2_QUANTIZATION 0x0104
+
+#define V4L2_MPEG2_PICTURE_CODING_TYPE_I	1
+#define V4L2_MPEG2_PICTURE_CODING_TYPE_P	2
+#define V4L2_MPEG2_PICTURE_CODING_TYPE_B	3
+#define V4L2_MPEG2_PICTURE_CODING_TYPE_D	4
+
+struct v4l2_mpeg2_sequence {
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Sequence header */
+	__u16	horizontal_size;
+	__u16	vertical_size;
+	__u32	vbv_buffer_size;
+
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Sequence extension */
+	__u8	profile_and_level_indication;
+	__u8	progressive_sequence;
+	__u8	chroma_format;
+	__u8	pad;
+};
+
+struct v4l2_mpeg2_picture {
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Picture header */
+	__u8	picture_coding_type;
+
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Picture coding extension */
+	__u8	f_code[2][2];
+	__u8	intra_dc_precision;
+	__u8	picture_structure;
+	__u8	top_field_first;
+	__u8	frame_pred_frame_dct;
+	__u8	concealment_motion_vectors;
+	__u8	q_scale_type;
+	__u8	intra_vlc_format;
+	__u8	alternate_scan;
+	__u8	repeat_first_field;
+	__u8	progressive_frame;
+	__u8	pad;
+};
+
+struct v4l2_ctrl_mpeg2_slice_params {
+	__u32	bit_size;
+	__u32	data_bit_offset;
+
+	struct v4l2_mpeg2_sequence sequence;
+	struct v4l2_mpeg2_picture picture;
+
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Slice */
+	__u8	quantiser_scale_code;
+
+	__u8	backward_ref_index;
+	__u8	forward_ref_index;
+	__u8	pad;
+};
+
+struct v4l2_ctrl_mpeg2_quantization {
+	/* ISO/IEC 13818-2, ITU-T Rec. H.262: Quant matrix extension */
+	__u8	load_intra_quantiser_matrix;
+	__u8	load_non_intra_quantiser_matrix;
+	__u8	load_chroma_intra_quantiser_matrix;
+	__u8	load_chroma_non_intra_quantiser_matrix;
+
+	__u8	intra_quantiser_matrix[64];
+	__u8	non_intra_quantiser_matrix[64];
+	__u8	chroma_intra_quantiser_matrix[64];
+	__u8	chroma_non_intra_quantiser_matrix[64];
+};
+
+#endif

--- a/src/mpeg2.c
+++ b/src/mpeg2.c
@@ -23,18 +23,20 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "mpeg2.h"
-#include "context.h"
-#include "request.h"
-#include "surface.h"
-
 #include <assert.h>
 #include <string.h>
 
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
+#include <linux/types.h>
 #include <linux/videodev2.h>
+
+#include "mpeg2-ctrls.h"
+#include "mpeg2.h"
+#include "context.h"
+#include "request.h"
+#include "surface.h"
 
 #include "v4l2.h"
 

--- a/src/video.c
+++ b/src/video.c
@@ -51,7 +51,7 @@ static struct video_format formats[] = {
 		.v4l2_buffers_count	= 1,
 		.v4l2_mplane		= false,
 		.drm_format		= DRM_FORMAT_NV12,
-		.drm_modifier		= DRM_FORMAT_MOD_ALLWINNER_MB32_TILED,
+		.drm_modifier		= DRM_FORMAT_MOD_ALLWINNER_TILED,
 		.planes_count		= 2,
 		.bpp			= 16
 	},


### PR DESCRIPTION
This pathset groups the needed updates to compile the libary on targets using linux kernel 5.0

-  configure.ac: Check for the availibility of a recent header of fourcc.h 
   - if uapi version of the 5.0 kernel is already incorporated in the libdrm system header,
  DRM_FORMAT_MOD_ALLWINNER_TILED is defined. We are going to use this header
   - otherwise, we will use the kernel version of drm
   is is suboptimal, but the only way to make use of sunxi VE enhancements

- h.264: update code to use new structures
  use types.h and update dbp structure field (buf_index to timestamp)

- h.265: update code to use new structures
  update dbp structure field (buf_index to timestamp)

- mpeg2.c: update code to use new structures
  - incorporate mpeg2-ctrls.h
  - RFC: should we integrate mpeg2-ctrls.h in mpeg2.h instead?

- video.c: update code to use new structure
  drm_modifier -> DRM_FORMAT_MOD_ALLWINNER_TILEDf