### PR TITLE
Image fixes

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -113,12 +113,12 @@ VAStatus RequestCreateImage(VADriverContextP context, VAImageFormat *format,
 	image->num_planes = destination_planes_count;
 	image->data_size = size;
 
-	image_object->image = *image;
-
 	for (i = 0; i < image->num_planes; i++) {
 		image->pitches[i] = destination_bytesperlines[i];
 		image->offsets[i] = i > 0 ? destination_sizes[i - 1] : 0;
 	}
+
+	image_object->image = *image;
 
 	return VA_STATUS_SUCCESS;
 }

--- a/src/surface.c
+++ b/src/surface.c
@@ -71,29 +71,35 @@ VAStatus RequestCreateSurfaces2(VADriverContextP context, unsigned int format,
 	if (format != VA_RT_FORMAT_YUV420)
 		return VA_STATUS_ERROR_UNSUPPORTED_RT_FORMAT;
 
-	found = v4l2_find_format(driver_data->video_fd,
-				 V4L2_BUF_TYPE_VIDEO_CAPTURE,
-				 V4L2_PIX_FMT_SUNXI_TILED_NV12);
-	if (found)
-		video_format = video_format_find(V4L2_PIX_FMT_SUNXI_TILED_NV12);
 
-	found = v4l2_find_format(driver_data->video_fd,
-				 V4L2_BUF_TYPE_VIDEO_CAPTURE,
-				 V4L2_PIX_FMT_NV12);
-	if (found)
-		video_format = video_format_find(V4L2_PIX_FMT_NV12);
+        if (!driver_data->video_format) {
+		found = v4l2_find_format(driver_data->video_fd,
+					 V4L2_BUF_TYPE_VIDEO_CAPTURE,
+					 V4L2_PIX_FMT_SUNXI_TILED_NV12);
+		if (found)
+			video_format = video_format_find(V4L2_PIX_FMT_SUNXI_TILED_NV12);
 
-	if (video_format == NULL)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
+		found = v4l2_find_format(driver_data->video_fd,
+					 V4L2_BUF_TYPE_VIDEO_CAPTURE,
+					 V4L2_PIX_FMT_NV12);
+		if (found)
+			video_format = video_format_find(V4L2_PIX_FMT_NV12);
 
-	driver_data->video_format = video_format;
+		if (video_format == NULL)
+			return VA_STATUS_ERROR_OPERATION_FAILED;
 
-	capture_type = v4l2_type_video_capture(video_format->v4l2_mplane);
+		driver_data->video_format = video_format;
 
-	rc = v4l2_set_format(driver_data->video_fd, capture_type,
-			     video_format->v4l2_format, width, height);
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
+		capture_type = v4l2_type_video_capture(video_format->v4l2_mplane);
+
+		rc = v4l2_set_format(driver_data->video_fd, capture_type,
+				     video_format->v4l2_format, width, height);
+		if (rc < 0)
+			return VA_STATUS_ERROR_OPERATION_FAILED;
+        } else {
+		video_format = driver_data->video_format;
+		capture_type = v4l2_type_video_capture(video_format->v4l2_mplane);
+	}
 
 	rc = v4l2_get_format(driver_data->video_fd, capture_type, &format_width,
 			     &format_height, destination_bytesperlines,


### PR DESCRIPTION
This my initial bug fix patchset to make this driver works with GStreamer. This makes the slow path works in NV12 with Cedrus driver.

```
export LIBVA_V4L2_REQUEST_VIDEO_PATH=/dev/video2
export LIBVA_V4L2_REQUEST_MEDIA_PATH=/dev/media1
export LIBVA_DRIVERS_PATH=~/libva-v4l2-request/build/src
export LIBVA_DRIVER_NAME=v4l2_request
export GST_VAAPI_DISABLE_VPP=1
export GST_VAAPI_ALL_DRIVERS=1
gst-launch-1.0 filesrc location=ken.mp4 ! parsebin ! vaapih264dec ! kmssink plane-properties=s,zpos=1
```