### PR TITLE
autotools: Query driver installation directory from libva (v3)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,11 @@ AM_PROG_AS
 PKG_CHECK_MODULES([LIBVA], [libva >= 1.1.0])
 PKG_CHECK_MODULES([DRM], [libdrm >= 2.4.52])
 
+PKG_CHECK_VAR([DRM_LIBDIR], [libdrm], [libdir],
+              [],
+              [AC_MSG_FAILURE([Unable to detect DRM libdir path.])]
+)
+
 #LIBS="$LIBS $DRM_LIBS"
 #CFLAGS="$CFLAGS $DRM_CFLAGS $LIBVA_CFLAGS"
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -62,6 +62,6 @@ v4l2_request_drv_video_la_LDFLAGS = -module -avoid-version -no-undefined \
 				    -Wl,--no-undefined
 v4l2_request_drv_video_la_LIBADD = $(DRM_LIBS) $(LIBVA_LIBS)
 v4l2_request_drv_video_la_LTLIBRARIES = v4l2_request_drv_video.la
-v4l2_request_drv_video_ladir = /usr/lib/dri/
+v4l2_request_drv_video_ladir = $(exec_prefix)$(LIBVA_DRIVER_PATH)
 
 MAINTAINERCLEANFILES = Makefile.in autoconfig.h.in


### PR DESCRIPTION
Instead of hardcoding installation path to `/usr/lib/dri/`, use `driverdir` variable from libva pkg config and also make sure `--prefix` option is respected.

**changes in v3**:
* Use the correct path variable also in the makefile

**changes in v2**:
* Use libva `driverdir` variable instead of libdrm