### PR TITLE
surface: fix status type

### DIFF
--- a/src/surface.h
+++ b/src/surface.h
@@ -40,7 +40,7 @@
 struct object_surface {
 	struct object_base base;
 
-	VAStatus status;
+	VASurfaceStatus status;
 	int width;
 	int height;
 


### PR DESCRIPTION
Correct the type of the surface object's status property to VASurfaceStatus.