### PR TITLE
Tile format

### DIFF
--- a/src/image.c
+++ b/src/image.c
@@ -33,7 +33,9 @@
 #include <assert.h>
 #include <string.h>
 
+#ifdef __arm__
 #include "tiled_yuv.h"
+#endif
 #include "utils.h"
 #include "v4l2.h"
 
@@ -155,6 +157,7 @@ static VAStatus copy_surface_to_image (struct request_data *driver_data,
 		return VA_STATUS_ERROR_INVALID_BUFFER;
 
 	for (i = 0; i < surface_object->destination_planes_count; i++) {
+#ifdef __arm__
 		if (!video_format_is_linear(driver_data->video_format))
 			tiled_to_planar(surface_object->destination_data[i],
 					buffer_object->data + image->offsets[i],
@@ -162,10 +165,13 @@ static VAStatus copy_surface_to_image (struct request_data *driver_data,
 					i == 0 ? image->height :
 						 image->height / 2);
 		else {
+#endif
 			memcpy(buffer_object->data + image->offsets[i],
 			       surface_object->destination_data[i],
 			       surface_object->destination_sizes[i]);
+#ifdef __arm__
 		}
+#endif
 	}
 
 	return VA_STATUS_SUCCESS;

--- a/src/tiled_yuv.S
+++ b/src/tiled_yuv.S
@@ -27,7 +27,7 @@
 .section .note.GNU-stack,"",%progbits /* mark stack as non-executable */
 #endif
 
-#ifndef __aarch64__
+#ifdef __arm__
 
 .text
 .syntax unified

--- a/src/video.c
+++ b/src/video.c
@@ -45,6 +45,8 @@ static struct video_format formats[] = {
 		.planes_count		= 2,
 		.bpp			= 16,
 	},
+// Code to handle this DRM_FORMAT is __arm__ only
+#ifdef __arm__
 	{
 		.description		= "Sunxi tiled NV12 YUV",
 		.v4l2_format		= V4L2_PIX_FMT_SUNXI_TILED_NV12,
@@ -55,6 +57,7 @@ static struct video_format formats[] = {
 		.planes_count		= 2,
 		.bpp			= 16
 	},
+#endif
 };
 
 static unsigned int formats_count = sizeof(formats) / sizeof(formats[0]);


### PR DESCRIPTION
This is an attempt to fix the build on aarch64 (and others architecture beyond arm).
As I understand, the tiled ASM is armv7 only, so can be discarded on "others arches".



