### PR TITLE
[wip] Rework backend for Linux 5.14

### DIFF
--- a/include/h264-ctrls.h
+++ b/include/h264-ctrls.h
@@ -14,7 +14,7 @@
 #include <linux/videodev2.h>
 
 /* Our pixel format isn't stable at the moment */
-#define V4L2_PIX_FMT_H264_SLICE_RAW v4l2_fourcc('S', '2', '6', '4') /* H264 parsed slices */
+#define V4L2_PIX_FMT_H264_SLICE v4l2_fourcc('S', '2', '6', '4') /* H264 parsed slices */
 
 /*
  * This is put insanely high to avoid conflicting with controls that
@@ -26,6 +26,8 @@
 #define V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX	(V4L2_CID_MPEG_BASE+1002)
 #define V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS	(V4L2_CID_MPEG_BASE+1003)
 #define V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS	(V4L2_CID_MPEG_BASE+1004)
+#define V4L2_CID_MPEG_VIDEO_H264_DECODE_MODE	(V4L2_CID_MPEG_BASE+1005)
+#define V4L2_CID_MPEG_VIDEO_H264_START_CODE	(V4L2_CID_MPEG_BASE+1006)
 
 /* enum v4l2_ctrl_type type values */
 #define V4L2_CTRL_TYPE_H264_SPS			0x0110
@@ -33,6 +35,16 @@
 #define V4L2_CTRL_TYPE_H264_SCALING_MATRIX	0x0112
 #define V4L2_CTRL_TYPE_H264_SLICE_PARAMS	0x0113
 #define V4L2_CTRL_TYPE_H264_DECODE_PARAMS	0x0114
+
+enum v4l2_mpeg_video_h264_decode_mode {
+	V4L2_MPEG_VIDEO_H264_DECODE_MODE_SLICE_BASED,
+	V4L2_MPEG_VIDEO_H264_DECODE_MODE_FRAME_BASED,
+};
+
+enum v4l2_mpeg_video_h264_start_code {
+	V4L2_MPEG_VIDEO_H264_START_CODE_NONE,
+	V4L2_MPEG_VIDEO_H264_START_CODE_ANNEX_B,
+};
 
 #define V4L2_H264_SPS_CONSTRAINT_SET0_FLAG			0x01
 #define V4L2_H264_SPS_CONSTRAINT_SET1_FLAG			0x02
@@ -125,6 +137,10 @@ struct v4l2_h264_pred_weight_table {
 struct v4l2_ctrl_h264_slice_params {
 	/* Size in bytes, including header */
 	__u32 size;
+
+	/* Offset in bytes to the start of slice in the OUTPUT buffer. */
+	__u32 start_byte_offset;
+
 	/* Offset in bits to slice_data() from the beginning of this slice. */
 	__u32 header_bit_size;
 
@@ -186,9 +202,6 @@ struct v4l2_ctrl_h264_decode_params {
 	struct v4l2_h264_dpb_entry dpb[16];
 	__u16 num_slices;
 	__u16 nal_ref_idc;
-	__u8 ref_pic_list_p0[32];
-	__u8 ref_pic_list_b0[32];
-	__u8 ref_pic_list_b1[32];
 	__s32 top_field_order_cnt;
 	__s32 bottom_field_order_cnt;
 	__u32 flags; /* V4L2_H264_DECODE_PARAM_FLAG_* */

--- a/src/config.c
+++ b/src/config.c
@@ -128,7 +128,7 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
-				 V4L2_PIX_FMT_H264_SLICE_RAW);
+				 V4L2_PIX_FMT_H264_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 5)) {
 		profiles[index++] = VAProfileH264Main;
 		profiles[index++] = VAProfileH264High;

--- a/src/config.c
+++ b/src/config.c
@@ -35,7 +35,6 @@
 #include <linux/videodev2.h>
 
 #include <mpeg2-ctrls.h>
-#include <h264-ctrls.h>
 #include <hevc-ctrls.h>
 
 #include "utils.h"

--- a/src/config.c
+++ b/src/config.c
@@ -53,18 +53,17 @@ VAStatus RequestCreateConfig(VADriverContextP context, VAProfile profile,
 	int i, index;
 
 	switch (profile) {
-	case VAProfileMPEG2Simple:
-	case VAProfileMPEG2Main:
+	
 	case VAProfileH264Main:
 	case VAProfileH264High:
 	case VAProfileH264ConstrainedBaseline:
 	case VAProfileH264MultiviewHigh:
 	case VAProfileH264StereoHigh:
-		case VAProfileHEVCMain:
-		if (entrypoint != VAEntrypointVLD)
-			return VA_STATUS_ERROR_UNSUPPORTED_ENTRYPOINT;
+		// FIXME
 		break;
-
+	case VAProfileMPEG2Simple:
+	case VAProfileMPEG2Main:
+	case VAProfileHEVCMain:
 	default:
 		return VA_STATUS_ERROR_UNSUPPORTED_PROFILE;
 	}

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,7 @@ struct object_config {
 	VAEntrypoint entrypoint;
 	VAConfigAttrib attributes[V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES];
 	int attributes_count;
+	unsigned int pixelformat;
 };
 
 VAStatus RequestCreateConfig(VADriverContextP context, VAProfile profile,

--- a/src/context.c
+++ b/src/context.c
@@ -105,6 +105,8 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 	case VAProfileH264MultiviewHigh:
 	case VAProfileH264StereoHigh:
 		pixelformat = V4L2_PIX_FMT_H264_SLICE;
+		/* Query decode mode and start code */
+		h264_get_controls(driver_data, context_object);
 		break;
 
 	case VAProfileHEVCMain:

--- a/src/context.c
+++ b/src/context.c
@@ -40,7 +40,6 @@
 #include <linux/videodev2.h>
 
 #include <mpeg2-ctrls.h>
-#include <h264-ctrls.h>
 #include <hevc-ctrls.h>
 
 #include "utils.h"
@@ -65,7 +64,6 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 	VAContextID id;
 	VAStatus status;
 	unsigned int output_type, capture_type;
-	unsigned int pixelformat;
 	unsigned int index_base;
 	unsigned int index;
 	unsigned int i;
@@ -91,39 +89,6 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 		goto error;
 	}
 	memset(&context_object->dpb, 0, sizeof(context_object->dpb));
-
-	switch (config_object->profile) {
-
-	case VAProfileMPEG2Simple:
-	case VAProfileMPEG2Main:
-		pixelformat = V4L2_PIX_FMT_MPEG2_SLICE;
-		break;
-
-	case VAProfileH264Main:
-	case VAProfileH264High:
-	case VAProfileH264ConstrainedBaseline:
-	case VAProfileH264MultiviewHigh:
-	case VAProfileH264StereoHigh:
-		pixelformat = V4L2_PIX_FMT_H264_SLICE;
-		/* Query decode mode and start code */
-		h264_get_controls(driver_data, context_object);
-		break;
-
-	case VAProfileHEVCMain:
-		pixelformat = V4L2_PIX_FMT_HEVC_SLICE;
-		break;
-
-	default:
-		status = VA_STATUS_ERROR_UNSUPPORTED_PROFILE;
-		goto error;
-	}
-
-	rc = v4l2_set_format(driver_data->video_fd, output_type, pixelformat,
-			     picture_width, picture_height);
-	if (rc < 0) {
-		status = VA_STATUS_ERROR_OPERATION_FAILED;
-		goto error;
-	}
 
 	rc = v4l2_create_buffers(driver_data->video_fd, output_type,
 				 surfaces_count, &index_base);

--- a/src/context.c
+++ b/src/context.c
@@ -104,7 +104,7 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 	case VAProfileH264ConstrainedBaseline:
 	case VAProfileH264MultiviewHigh:
 	case VAProfileH264StereoHigh:
-		pixelformat = V4L2_PIX_FMT_H264_SLICE_RAW;
+		pixelformat = V4L2_PIX_FMT_H264_SLICE;
 		break;
 
 	case VAProfileHEVCMain:

--- a/src/context.h
+++ b/src/context.h
@@ -50,6 +50,7 @@ struct object_context {
 
 	/* H264 only */
 	struct h264_dpb dpb;
+	bool h264_start_code;
 };
 
 VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,

--- a/src/h264.c
+++ b/src/h264.c
@@ -435,31 +435,32 @@ int h264_set_controls(struct request_data *driver_data,
 			      &surface->params.h264.slice,
 			      &surface->params.h264.picture, &slice);
 
-	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS, &decode,
-			      sizeof(decode));
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
+	struct v4l2_ext_control controls[5] = {
+		{
+			.id = V4L2_CID_MPEG_VIDEO_H264_SPS,
+			.ptr = &sps,
+			.size = sizeof(sps),
+		}, {
+			.id = V4L2_CID_MPEG_VIDEO_H264_PPS,
+			.ptr = &pps,
+			.size = sizeof(pps),
+		}, {
+			.id = V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX,
+			.ptr = &matrix,
+			.size = sizeof(matrix),
+		}, {
+			.id = V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS,
+			.ptr = &slice,
+			.size = sizeof(slice),
+		}, {
+			.id = V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS,
+			.ptr = &decode,
+			.size = sizeof(decode),
+		}
+	};
 
-	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS, &slice,
-			      sizeof(slice));
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
-
-	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_PPS, &pps, sizeof(pps));
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
-
-	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SPS, &sps, sizeof(sps));
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
-
-	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX, &matrix,
-			      sizeof(matrix));
+	rc = v4l2_set_controls(driver_data->video_fd, surface->request_fd,
+			       controls, 5);
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 

--- a/src/h264.c
+++ b/src/h264.c
@@ -270,6 +270,7 @@ static void h264_va_picture_to_v4l2(struct request_data *driver_data,
 	if (VAPicture->pic_fields.bits.redundant_pic_cnt_present_flag)
 		pps->flags |= V4L2_H264_PPS_FLAG_REDUNDANT_PIC_CNT_PRESENT;
 
+	sps->max_num_ref_frames = VAPicture->num_ref_frames;
 	sps->chroma_format_idc = VAPicture->seq_fields.bits.chroma_format_idc;
 	sps->bit_depth_luma_minus8 = VAPicture->bit_depth_luma_minus8;
 	sps->bit_depth_chroma_minus8 = VAPicture->bit_depth_chroma_minus8;

--- a/src/h264.c
+++ b/src/h264.c
@@ -197,6 +197,7 @@ static void h264_fill_dpb(struct request_data *data,
 		}
 
 		dpb->frame_num = entry->pic.frame_idx;
+		dpb->pic_num = entry->pic.picture_id;
 		dpb->top_field_order_cnt = entry->pic.TopFieldOrderCnt;
 		dpb->bottom_field_order_cnt = entry->pic.BottomFieldOrderCnt;
 

--- a/src/h264.c
+++ b/src/h264.c
@@ -219,9 +219,23 @@ static void h264_va_picture_to_v4l2(struct request_data *driver_data,
 				    struct v4l2_ctrl_h264_pps *pps,
 				    struct v4l2_ctrl_h264_sps *sps)
 {
+	unsigned char *b;
+	unsigned char nal_ref_idc;
+	unsigned char nal_unit_type;
+
+	/* Extract missing nal_ref_idc and nal_unit_type */
+	b = surface->source_data;
+	if (context->h264_start_code)
+		b += 3;
+	nal_ref_idc = (b[0] >> 5) & 0x3;
+	nal_unit_type = b[0] & 0x1f;
+
 	h264_fill_dpb(driver_data, context, decode);
 
 	decode->num_slices = surface->slices_count;
+	decode->nal_ref_idc = nal_ref_idc;
+	if (nal_unit_type == 5)
+		decode->flags = V4L2_H264_DECODE_PARAM_FLAG_IDR_PIC;
 	decode->top_field_order_cnt = VAPicture->CurrPic.TopFieldOrderCnt;
 	decode->bottom_field_order_cnt = VAPicture->CurrPic.BottomFieldOrderCnt;
 

--- a/src/h264.c
+++ b/src/h264.c
@@ -330,6 +330,8 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 				  struct v4l2_ctrl_h264_slice_params *slice)
 {
 	slice->size = VASlice->slice_data_size;
+	if (context->h264_start_code)
+		slice->size += 3;
 	slice->header_bit_size = VASlice->slice_data_bit_offset;
 	slice->first_mb_in_slice = VASlice->first_mb_in_slice;
 	slice->slice_type = VASlice->slice_type;

--- a/src/h264.c
+++ b/src/h264.c
@@ -405,6 +405,46 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 				     VASlice->chroma_offset_l1);
 }
 
+int h264_get_controls(struct request_data *driver_data,
+		      struct object_context *context)
+{
+	struct v4l2_ext_control controls[2] = {
+		{
+			.id = V4L2_CID_MPEG_VIDEO_H264_DECODE_MODE,
+		}, {
+			.id = V4L2_CID_MPEG_VIDEO_H264_START_CODE,
+		}
+	};
+	int rc;
+
+	rc = v4l2_get_controls(driver_data->video_fd, -1, controls, 2);
+	if (rc < 0)
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+
+	switch (controls[0].value) {
+	case V4L2_MPEG_VIDEO_H264_DECODE_MODE_SLICE_BASED:
+		break;
+	case V4L2_MPEG_VIDEO_H264_DECODE_MODE_FRAME_BASED:
+		break;
+	default:
+		request_log("Unsupported decode mode\n");
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+	}
+
+	switch (controls[1].value) {
+	case V4L2_MPEG_VIDEO_H264_START_CODE_NONE:
+		break;
+	case V4L2_MPEG_VIDEO_H264_START_CODE_ANNEX_B:
+		context->h264_start_code = true;
+		break;
+	default:
+		request_log("Unsupported start code\n");
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+	}
+
+	return VA_STATUS_SUCCESS;
+}
+
 int h264_set_controls(struct request_data *driver_data,
 		      struct object_context *context,
 		      struct object_surface *surface)

--- a/src/h264.c
+++ b/src/h264.c
@@ -464,8 +464,27 @@ int h264_get_controls(struct request_data *driver_data,
 	return VA_STATUS_SUCCESS;
 }
 
+static inline __u8 h264_profile_to_idc(VAProfile profile)
+{
+	switch (profile) {
+	case VAProfileH264Main:
+		return 77;
+	case VAProfileH264High:
+		return 100;
+	case VAProfileH264ConstrainedBaseline:
+		return 66;
+	case VAProfileH264MultiviewHigh:
+		return 118;
+	case VAProfileH264StereoHigh:
+		return 128;
+	default:
+		return 0;
+	}
+}
+
 int h264_set_controls(struct request_data *driver_data,
 		      struct object_context *context,
+		      VAProfile profile,
 		      struct object_surface *surface)
 {
 	struct v4l2_ctrl_h264_scaling_matrix matrix = { 0 };
@@ -493,6 +512,8 @@ int h264_set_controls(struct request_data *driver_data,
 	h264_va_slice_to_v4l2(driver_data, context,
 			      &surface->params.h264.slice,
 			      &surface->params.h264.picture, &slice);
+
+	sps.profile_idc = h264_profile_to_idc(profile);
 
 	struct v4l2_ext_control controls[5] = {
 		{

--- a/src/h264.c
+++ b/src/h264.c
@@ -336,6 +336,7 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 	slice->header_bit_size = VASlice->slice_data_bit_offset;
 	slice->first_mb_in_slice = VASlice->first_mb_in_slice;
 	slice->slice_type = VASlice->slice_type;
+	slice->frame_num = VAPicture->frame_num;
 	slice->cabac_init_idc = VASlice->cabac_init_idc;
 	slice->slice_qp_delta = VASlice->slice_qp_delta;
 	slice->disable_deblocking_filter_idc =

--- a/src/h264.h
+++ b/src/h264.h
@@ -51,6 +51,8 @@ struct h264_dpb {
 	unsigned int age;
 };
 
+int h264_get_controls(struct request_data *driver_data,
+		      struct object_context *context);
 int h264_set_controls(struct request_data *data,
 		      struct object_context *context,
 		      struct object_surface *surface);

--- a/src/h264.h
+++ b/src/h264.h
@@ -55,6 +55,7 @@ int h264_get_controls(struct request_data *driver_data,
 		      struct object_context *context);
 int h264_set_controls(struct request_data *data,
 		      struct object_context *context,
+		      VAProfile profile,
 		      struct object_surface *surface);
 
 #endif

--- a/src/image.c
+++ b/src/image.c
@@ -155,6 +155,7 @@ static VAStatus copy_surface_to_image (struct request_data *driver_data,
 		return VA_STATUS_ERROR_INVALID_BUFFER;
 
 	for (i = 0; i < surface_object->destination_planes_count; i++) {
+#ifdef __arm__
 		if (!video_format_is_linear(driver_data->video_format))
 			tiled_to_planar(surface_object->destination_data[i],
 					buffer_object->data + image->offsets[i],
@@ -162,10 +163,13 @@ static VAStatus copy_surface_to_image (struct request_data *driver_data,
 					i == 0 ? image->height :
 						 image->height / 2);
 		else {
+#endif
 			memcpy(buffer_object->data + image->offsets[i],
 			       surface_object->destination_data[i],
 			       surface_object->destination_sizes[i]);
+#ifdef __arm__
 		}
+#endif
 	}
 
 	return VA_STATUS_SUCCESS;

--- a/src/picture.c
+++ b/src/picture.c
@@ -193,7 +193,8 @@ static VAStatus codec_set_controls(struct request_data *driver_data,
 	case VAProfileH264ConstrainedBaseline:
 	case VAProfileH264MultiviewHigh:
 	case VAProfileH264StereoHigh:
-		rc = h264_set_controls(driver_data, context, surface_object);
+		rc = h264_set_controls(driver_data, context, profile,
+				       surface_object);
 		if (rc < 0)
 			return VA_STATUS_ERROR_OPERATION_FAILED;
 		break;

--- a/src/surface.h
+++ b/src/surface.h
@@ -40,7 +40,7 @@
 struct object_surface {
 	struct object_base base;
 
-	VAStatus status;
+	VASurfaceStatus status;
 	int width;
 	int height;
 

--- a/src/tiled_yuv.S
+++ b/src/tiled_yuv.S
@@ -27,7 +27,7 @@
 .section .note.GNU-stack,"",%progbits /* mark stack as non-executable */
 #endif
 
-#ifndef __aarch64__
+#ifdef __arm__
 
 .text
 .syntax unified

--- a/src/v4l2.c
+++ b/src/v4l2.c
@@ -428,22 +428,17 @@ int v4l2_export_buffer(int video_fd, unsigned int type, unsigned int index,
 	return 0;
 }
 
-int v4l2_set_control(int video_fd, int request_fd, unsigned int id, void *data,
-		     unsigned int size)
+int v4l2_set_controls(int video_fd, int request_fd,
+		      struct v4l2_ext_control *control_array,
+		      unsigned int num_controls)
 {
-	struct v4l2_ext_control control;
 	struct v4l2_ext_controls controls;
 	int rc;
 
-	memset(&control, 0, sizeof(control));
 	memset(&controls, 0, sizeof(controls));
 
-	control.id = id;
-	control.ptr = data;
-	control.size = size;
-
-	controls.controls = &control;
-	controls.count = 1;
+	controls.controls = control_array;
+	controls.count = num_controls;
 
 	if (request_fd >= 0) {
 		controls.which = V4L2_CTRL_WHICH_REQUEST_VAL;
@@ -452,11 +447,25 @@ int v4l2_set_control(int video_fd, int request_fd, unsigned int id, void *data,
 
 	rc = ioctl(video_fd, VIDIOC_S_EXT_CTRLS, &controls);
 	if (rc < 0) {
-		request_log("Unable to set control: %s\n", strerror(errno));
+		request_log("Unable to set control(s): %s\n", strerror(errno));
 		return -1;
 	}
 
 	return 0;
+}
+
+int v4l2_set_control(int video_fd, int request_fd, unsigned int id, void *data,
+		     unsigned int size)
+{
+	struct v4l2_ext_control control;
+
+	memset(&control, 0, sizeof(control));
+
+	control.id = id;
+	control.ptr = data;
+	control.size = size;
+
+	return v4l2_set_controls(video_fd, request_fd, &control, 1);
 }
 
 int v4l2_set_stream(int video_fd, unsigned int type, bool enable)

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -54,6 +54,9 @@ int v4l2_dequeue_buffer(int video_fd, int request_fd, unsigned int type,
 int v4l2_export_buffer(int video_fd, unsigned int type, unsigned int index,
 		       unsigned int flags, int *export_fds,
 		       unsigned int export_fds_count);
+int v4l2_set_controls(int video_fd, int request_fd,
+		      struct v4l2_ext_control *controls,
+		      unsigned int num_controls);
 int v4l2_set_control(int video_fd, int request_fd, unsigned int id, void *data,
 		     unsigned int size);
 int v4l2_set_stream(int video_fd, unsigned int type, bool enable);

--- a/src/v4l2.h
+++ b/src/v4l2.h
@@ -54,6 +54,9 @@ int v4l2_dequeue_buffer(int video_fd, int request_fd, unsigned int type,
 int v4l2_export_buffer(int video_fd, unsigned int type, unsigned int index,
 		       unsigned int flags, int *export_fds,
 		       unsigned int export_fds_count);
+int v4l2_get_controls(int video_fd, int request_fd,
+		      struct v4l2_ext_control *controls,
+		      unsigned int num_controls);
 int v4l2_set_controls(int video_fd, int request_fd,
 		      struct v4l2_ext_control *controls,
 		      unsigned int num_controls);


### PR DESCRIPTION
This PR is intended to fix builds against 5.14, as well as get all decoders into a good working state. It currently builds, but only decodes H.264 video in its current state; however, the fix should be relatively simple (detailed in acbdfb1).

Thanks to @wolfallein, @pH5, and everyone else in #35 for much of the initial work and investigation!