### PR TITLE
Kernel 6.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ config.sub
 configure
 depcomp
 TAGS
+error-fix

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ configure
 depcomp
 TAGS
 error-fix
+
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ TAGS
 error-fix
 
 build/
+DEVLOG*

--- a/README.md
+++ b/README.md
@@ -73,3 +73,110 @@ An Image is a standard data structure containing rendered frames in a usable
 pixel format. Here we only use NV12 buffers which are converted from sunxi's
 proprietary tiled pixel format with tiled_yuv when deriving an Image from a
 Surface.
+
+---
+
+# Kernel 6.x Port Addendum
+
+The sections below document the state of this tree after the port to
+the stable stateless codec API of kernel 6.x (tested against
+linux-headers 6.18). The original notes above are kept unchanged.
+See DEVLOG-kernel-6.18.md for the full story of the port.
+
+## What the program does
+
+The backend translates VA-API into the V4L2 Request API. The
+application talks regular VA-API to libva, and this driver turns each
+decode job into V4L2 stateless decoding requests: it fills the codec
+control structures (SPS, PPS, slice and decode parameters), copies the
+bitstream into V4L2 output buffers, ties everything together with a
+media request and queues it to the kernel driver. The hardware decoder
+writes the decoded frame into the capture buffer that backs the VA
+surface.
+
+Any V4L2 stateless decoder can be driven this way. Tested kernel
+drivers are cedrus (Allwinner) and rpivid (Raspberry Pi 4/400 HEVC).
+On the Pi, HEVC decoding has been verified bit-exact against software
+decoding at 720p and 1080p. H264 and MPEG2 still compile and probe,
+but the Pi has no stateless hardware for them.
+
+Known limitations:
+* Frames split into multiple slices only submit the parameters of the
+  last slice, so multi-slice streams may show artifacts.
+* HEVC scaling lists (IQ matrices) are not passed to the kernel yet.
+  VA-API provides them in diagonal scan order while V4L2 expects
+  raster order.
+* Zero-copy export of SAND128 (Raspberry Pi) surfaces through DMA-BUF
+  is untested. Use the copy path (vaGetImage / vaDeriveImage), which
+  untiles in software and is known good.
+
+## Building and installing with meson
+
+The project needs libva and libdrm development files plus the kernel
+uapi headers from a 6.x kernel:
+
+	meson setup build
+	ninja -C build
+	sudo ninja -C build install
+
+This installs `v4l2_request_drv_video.so` into the libva driver
+directory of the chosen prefix, for example `/usr/local/lib/dri`.
+
+## How to use
+
+The driver is selected through environment variables. The first one
+names the driver, the second one is only needed when the install
+prefix is not on the default libva search path:
+
+	export LIBVA_DRIVER_NAME=v4l2_request
+	export LIBVA_DRIVERS_PATH=/usr/local/lib/dri
+
+By default the backend opens `/dev/video0` and `/dev/media0`. Most
+boards register the decoder elsewhere, so point it at the right nodes.
+On a Raspberry Pi 4/400 the rpivid HEVC decoder is usually:
+
+	export LIBVA_V4L2_REQUEST_VIDEO_PATH=/dev/video19
+	export LIBVA_V4L2_REQUEST_MEDIA_PATH=/dev/media0
+
+To find the right nodes on your board, check `v4l2-ctl --list-devices`
+(from v4l-utils) or `dmesg | grep -i "registered as"`. The user also
+needs permission to open the video and media nodes, which usually
+means being in the `video` group:
+
+	sudo usermod -aG video $USER
+
+Then any VA-API capable player works:
+
+	mpv --hwdec=vaapi-copy path/to/video.mkv
+	ffplay -hwaccel vaapi path/to/video.mkv
+
+## How to verify
+
+Three levels of checking, from quick to thorough:
+
+1. Driver loads and reports profiles:
+
+		vainfo
+
+	Success looks like `Driver version: v4l2-request` followed by the
+	profile list (for example `VAProfileHEVCMain : VAEntrypointVLD`).
+	A `vaInitialize failed` error almost always means the environment
+	variables above are not set in the current shell.
+
+2. Hardware actually decodes. Decode a file through the driver and
+   watch for errors:
+
+		ffmpeg -hwaccel vaapi -hwaccel_device /dev/dri/card0 \
+			-i test.mkv -f null -
+
+	The backend logs its V4L2 calls to stderr (s_fmt, create_bufs,
+	streamon, dqbuf). If a frame fails in the kernel driver, the
+	dequeue reports an error flag and the kernel log explains why,
+	so also check `sudo dmesg`.
+
+3. Output is correct. Compare hardware and software decodes frame by
+   frame, the hashes must be identical:
+
+		ffmpeg -hwaccel vaapi -i test.mkv -vf format=nv12 -f framemd5 hw.md5
+		ffmpeg -i test.mkv -vf format=nv12 -f framemd5 sw.md5
+		diff hw.md5 sw.md5 && echo "bit-exact"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,17 @@ On the Pi, HEVC decoding has been verified bit-exact against software
 decoding at 720p and 1080p. H264 and MPEG2 still compile and probe,
 but the Pi has no stateless hardware for them.
 
+Important: this backend only works with stateless decoders (the V4L2
+Request API), because that is the model VA-API maps onto: the
+application parses the bitstream and hands pre-parsed parameters to
+the hardware for every frame. Stateful V4L2 decoders are a different
+interface where the hardware parses the bitstream itself, and they
+cannot be driven through this backend. Concretely, on a Raspberry Pi
+4/400 the H264 decoder (bcm2835-codec) is stateful, so HEVC via
+rpivid is the only codec this backend can accelerate there. For
+stateful decoders use them directly instead, for example FFmpeg's
+h264_v4l2m2m decoder.
+
 Known limitations:
 * Frames split into multiple slices only submit the parameters of the
   last slice, so multi-slice streams may show artifacts.

--- a/include/h264-ctrls.h
+++ b/include/h264-ctrls.h
@@ -11,6 +11,8 @@
 #ifndef _H264_CTRLS_H_
 #define _H264_CTRLS_H_
 
+#ifndef __LINUX_V4L2_CONTROLS_H
+
 #include <linux/videodev2.h>
 
 /* Our pixel format isn't stable at the moment */
@@ -194,4 +196,5 @@ struct v4l2_ctrl_h264_decode_params {
 	__u32 flags; /* V4L2_H264_DECODE_PARAM_FLAG_* */
 };
 
+#endif
 #endif

--- a/include/hevc-ctrls.h
+++ b/include/hevc-ctrls.h
@@ -7,6 +7,8 @@
  * more changes. So keep them private until they are stable and ready to
  * become part of the official public API.
  */
+#ifndef __LINUX_V4L2_CONTROLS_H
+
 
 #ifndef _HEVC_CTRLS_H_
 #define _HEVC_CTRLS_H_
@@ -27,6 +29,7 @@
 #define V4L2_HEVC_SLICE_TYPE_P	1
 #define V4L2_HEVC_SLICE_TYPE_I	2
 
+#ifndef V4L2_HEVC_STATELESS_HEVC_SPS
 /* The controls are not stable at the moment and will likely be reworked. */
 struct v4l2_ctrl_hevc_sps {
 	/* ISO/IEC 23008-2, ITU-T Rec. H.265: Sequence parameter set */
@@ -98,12 +101,15 @@ struct v4l2_ctrl_hevc_pps {
 	__u8	padding;
 };
 
+#endif
+
 #define V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_BEFORE	0x01
 #define V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_AFTER	0x02
 #define V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR		0x03
 
 #define V4L2_HEVC_DPB_ENTRIES_NUM_MAX		16
 
+#ifndef V4L2_HEVC_STATELESS_HEVC_SPS
 struct v4l2_hevc_dpb_entry {
 	__u64	timestamp;
 	__u8	rps;
@@ -181,5 +187,6 @@ struct v4l2_ctrl_hevc_slice_params {
 
 	__u8	padding[2];
 };
-
+#endif
+#endif
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -128,7 +128,7 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
-				 V4L2_PIX_FMT_H264_SLICE_RAW);
+				 V4L2_PIX_FMT_H264_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 5)) {
 		profiles[index++] = VAProfileH264Main;
 		profiles[index++] = VAProfileH264High;

--- a/src/config.c
+++ b/src/config.c
@@ -34,9 +34,7 @@
 
 #include <linux/videodev2.h>
 
-#include <mpeg2-ctrls.h>
-#include <h264-ctrls.h>
-#include <hevc-ctrls.h>
+#include <linux/v4l2-controls.h>
 
 #include "utils.h"
 #include "v4l2.h"

--- a/src/config.c
+++ b/src/config.c
@@ -118,6 +118,9 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
+				 V4L2_PIX_FMT_MPEG2_SLICE) ||
+		v4l2_find_format(driver_data->video_fd,
+				 V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE,
 				 V4L2_PIX_FMT_MPEG2_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 2)) {
 		profiles[index++] = VAProfileMPEG2Simple;
@@ -126,6 +129,9 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
+				 V4L2_PIX_FMT_H264_SLICE) ||
+		v4l2_find_format(driver_data->video_fd,
+				 V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE,
 				 V4L2_PIX_FMT_H264_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 5)) {
 		profiles[index++] = VAProfileH264Main;
@@ -137,6 +143,9 @@ VAStatus RequestQueryConfigProfiles(VADriverContextP context,
 
 	found = v4l2_find_format(driver_data->video_fd,
 				 V4L2_BUF_TYPE_VIDEO_OUTPUT,
+				 V4L2_PIX_FMT_HEVC_SLICE) ||
+		v4l2_find_format(driver_data->video_fd,
+				 V4L2_BUF_TYPE_VIDEO_OUTPUT_MPLANE,
 				 V4L2_PIX_FMT_HEVC_SLICE);
 	if (found && index < (V4L2_REQUEST_MAX_CONFIG_ATTRIBUTES - 1))
 		profiles[index++] = VAProfileHEVCMain;

--- a/src/context.c
+++ b/src/context.c
@@ -104,7 +104,7 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 	case VAProfileH264ConstrainedBaseline:
 	case VAProfileH264MultiviewHigh:
 	case VAProfileH264StereoHigh:
-		pixelformat = V4L2_PIX_FMT_H264_SLICE_RAW;
+		pixelformat = V4L2_PIX_FMT_H264_SLICE;
 		break;
 
 	case VAProfileHEVCMain:

--- a/src/context.c
+++ b/src/context.c
@@ -39,9 +39,7 @@
 
 #include <linux/videodev2.h>
 
-#include <mpeg2-ctrls.h>
-#include <h264-ctrls.h>
-#include <hevc-ctrls.h>
+#include <linux/v4l2-controls.h>
 
 #include "utils.h"
 #include "v4l2.h"

--- a/src/context.c
+++ b/src/context.c
@@ -121,12 +121,25 @@ VAStatus RequestCreateContext(VADriverContextP context, VAConfigID config_id,
 		goto error;
 	}
 
+	/*
+	 * Modern libva clients (e.g. FFmpeg) create the context without
+	 * render targets and create surfaces dynamically afterwards, so
+	 * make sure the output queue gets a usable buffer pool either way.
+	 * Decoding is synchronous (EndPicture waits for the request), so a
+	 * small shared pool is sufficient.
+	 */
 	rc = v4l2_create_buffers(driver_data->video_fd, output_type,
-				 surfaces_count, &index_base);
+				 surfaces_count > 0 ? surfaces_count : 4,
+				 &index_base);
 	if (rc < 0) {
 		status = VA_STATUS_ERROR_ALLOCATION_FAILED;
 		goto error;
 	}
+
+	context_object->source_index_base = index_base;
+	context_object->source_buffers_count =
+		surfaces_count > 0 ? surfaces_count : 4;
+	context_object->source_next = 0;
 
 	/*
 	 * The surface_ids array has been allocated by the caller and

--- a/src/context.h
+++ b/src/context.h
@@ -44,6 +44,15 @@ struct object_context {
 	VASurfaceID *surfaces_ids;
 	int surfaces_count;
 
+	/*
+	 * Pool of V4L2 output (bitstream) buffers, attached to surfaces
+	 * lazily: modern libva clients create contexts with no render
+	 * targets and add surfaces dynamically afterwards.
+	 */
+	unsigned int source_index_base;
+	unsigned int source_buffers_count;
+	unsigned int source_next;
+
 	int picture_width;
 	int picture_height;
 	int flags;

--- a/src/h264.c
+++ b/src/h264.c
@@ -436,29 +436,29 @@ int h264_set_controls(struct request_data *driver_data,
 			      &surface->params.h264.picture, &slice);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_DECODE_PARAMS, &decode,
+			      V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, &decode,
 			      sizeof(decode));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SLICE_PARAMS, &slice,
+			      V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, &slice,
 			      sizeof(slice));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_PPS, &pps, sizeof(pps));
+			      V4L2_CID_MPEG_VIDEO_H264_FMO, &pps, sizeof(pps));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SPS, &sps, sizeof(sps));
+			      V4L2_CID_MPEG_VIDEO_H264_FMO, &sps, sizeof(sps));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_SCALING_MATRIX, &matrix,
+			      V4L2_CID_STATELESS_H264_SCALING_MATRIX, &matrix,
 			      sizeof(matrix));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;

--- a/src/h264.c
+++ b/src/h264.c
@@ -33,7 +33,7 @@
 #include <sys/mman.h>
 
 #include <linux/videodev2.h>
-#include <h264-ctrls.h>
+#include <linux/v4l2-controls.h>
 
 #include "request.h"
 #include "surface.h"
@@ -196,7 +196,9 @@ static void h264_fill_dpb(struct request_data *data,
 			dpb->reference_ts = timestamp;
 		}
 
+		dpb->pic_num = entry->pic.frame_idx;
 		dpb->frame_num = entry->pic.frame_idx;
+		dpb->fields = V4L2_H264_FRAME_REF;
 		dpb->top_field_order_cnt = entry->pic.TopFieldOrderCnt;
 		dpb->bottom_field_order_cnt = entry->pic.BottomFieldOrderCnt;
 
@@ -220,9 +222,16 @@ static void h264_va_picture_to_v4l2(struct request_data *driver_data,
 {
 	h264_fill_dpb(driver_data, context, decode);
 
-	decode->num_slices = surface->slices_count;
+	decode->frame_num = VAPicture->frame_num;
+	decode->nal_ref_idc = VAPicture->pic_fields.bits.reference_pic_flag;
 	decode->top_field_order_cnt = VAPicture->CurrPic.TopFieldOrderCnt;
 	decode->bottom_field_order_cnt = VAPicture->CurrPic.BottomFieldOrderCnt;
+
+	if (VAPicture->pic_fields.bits.field_pic_flag)
+		decode->flags |= V4L2_H264_DECODE_PARAM_FLAG_FIELD_PIC;
+
+	if (VAPicture->CurrPic.flags & VA_PICTURE_H264_BOTTOM_FIELD)
+		decode->flags |= V4L2_H264_DECODE_PARAM_FLAG_BOTTOM_FIELD;
 
 	pps->weighted_bipred_idc =
 		VAPicture->pic_fields.bits.weighted_bipred_idc;
@@ -255,6 +264,9 @@ static void h264_va_picture_to_v4l2(struct request_data *driver_data,
 	if (VAPicture->pic_fields.bits.redundant_pic_cnt_present_flag)
 		pps->flags |= V4L2_H264_PPS_FLAG_REDUNDANT_PIC_CNT_PRESENT;
 
+	/* The scaling matrix is always passed through a dedicated control. */
+	pps->flags |= V4L2_H264_PPS_FLAG_SCALING_MATRIX_PRESENT;
+
 	sps->chroma_format_idc = VAPicture->seq_fields.bits.chroma_format_idc;
 	sps->bit_depth_luma_minus8 = VAPicture->bit_depth_luma_minus8;
 	sps->bit_depth_chroma_minus8 = VAPicture->bit_depth_chroma_minus8;
@@ -263,6 +275,7 @@ static void h264_va_picture_to_v4l2(struct request_data *driver_data,
 	sps->log2_max_pic_order_cnt_lsb_minus4 =
 		VAPicture->seq_fields.bits.log2_max_pic_order_cnt_lsb_minus4;
 	sps->pic_order_cnt_type = VAPicture->seq_fields.bits.pic_order_cnt_type;
+	sps->max_num_ref_frames = VAPicture->num_ref_frames;
 	sps->pic_width_in_mbs_minus1 = VAPicture->picture_width_in_mbs_minus1;
 	sps->pic_height_in_map_units_minus1 =
 		VAPicture->picture_height_in_mbs_minus1;
@@ -327,9 +340,9 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 				  struct object_context *context,
 				  VASliceParameterBufferH264 *VASlice,
 				  VAPictureParameterBufferH264 *VAPicture,
-				  struct v4l2_ctrl_h264_slice_params *slice)
+				  struct v4l2_ctrl_h264_slice_params *slice,
+				  struct v4l2_ctrl_h264_pred_weights *weights)
 {
-	slice->size = VASlice->slice_data_size;
 	slice->header_bit_size = VASlice->slice_data_bit_offset;
 	slice->first_mb_in_slice = VASlice->first_mb_in_slice;
 	slice->slice_type = VASlice->slice_type;
@@ -356,7 +369,8 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 			if (!entry)
 				continue;
 
-			slice->ref_pic_list0[i] = idx;
+			slice->ref_pic_list0[i].index = idx;
+			slice->ref_pic_list0[i].fields = V4L2_H264_FRAME_REF;
 		}
 	}
 
@@ -375,21 +389,20 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 			if (!entry)
 				continue;
 
-			slice->ref_pic_list1[i] = idx;
+			slice->ref_pic_list1[i].index = idx;
+			slice->ref_pic_list1[i].fields = V4L2_H264_FRAME_REF;
 		}
 	}
 
 	if (VASlice->direct_spatial_mv_pred_flag)
 		slice->flags |= V4L2_H264_SLICE_FLAG_DIRECT_SPATIAL_MV_PRED;
 
-	slice->pred_weight_table.chroma_log2_weight_denom =
-		VASlice->chroma_log2_weight_denom;
-	slice->pred_weight_table.luma_log2_weight_denom =
-		VASlice->luma_log2_weight_denom;
+	weights->chroma_log2_weight_denom = VASlice->chroma_log2_weight_denom;
+	weights->luma_log2_weight_denom = VASlice->luma_log2_weight_denom;
 
 	if (((VASlice->slice_type % 5) == H264_SLICE_P) ||
 	    ((VASlice->slice_type % 5) == H264_SLICE_B))
-		h264_copy_pred_table(&slice->pred_weight_table.weight_factors[0],
+		h264_copy_pred_table(&weights->weight_factors[0],
 				     slice->num_ref_idx_l0_active_minus1 + 1,
 				     VASlice->luma_weight_l0,
 				     VASlice->luma_offset_l0,
@@ -397,7 +410,7 @@ static void h264_va_slice_to_v4l2(struct request_data *driver_data,
 				     VASlice->chroma_offset_l0);
 
 	if ((VASlice->slice_type % 5) == H264_SLICE_B)
-		h264_copy_pred_table(&slice->pred_weight_table.weight_factors[1],
+		h264_copy_pred_table(&weights->weight_factors[1],
 				     slice->num_ref_idx_l1_active_minus1 + 1,
 				     VASlice->luma_weight_l1,
 				     VASlice->luma_offset_l1,
@@ -412,6 +425,7 @@ int h264_set_controls(struct request_data *driver_data,
 	struct v4l2_ctrl_h264_scaling_matrix matrix = { 0 };
 	struct v4l2_ctrl_h264_decode_params decode = { 0 };
 	struct v4l2_ctrl_h264_slice_params slice = { 0 };
+	struct v4l2_ctrl_h264_pred_weights weights = { 0 };
 	struct v4l2_ctrl_h264_pps pps = { 0 };
 	struct v4l2_ctrl_h264_sps sps = { 0 };
 	struct h264_dpb_entry *output;
@@ -433,27 +447,33 @@ int h264_set_controls(struct request_data *driver_data,
 			       &surface->params.h264.matrix, &matrix);
 	h264_va_slice_to_v4l2(driver_data, context,
 			      &surface->params.h264.slice,
-			      &surface->params.h264.picture, &slice);
+			      &surface->params.h264.picture, &slice, &weights);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, &decode,
+			      V4L2_CID_STATELESS_H264_DECODE_PARAMS, &decode,
 			      sizeof(decode));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, &slice,
+			      V4L2_CID_STATELESS_H264_SLICE_PARAMS, &slice,
 			      sizeof(slice));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_FMO, &pps, sizeof(pps));
+			      V4L2_CID_STATELESS_H264_PRED_WEIGHTS, &weights,
+			      sizeof(weights));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
-			      V4L2_CID_MPEG_VIDEO_H264_FMO, &sps, sizeof(sps));
+			      V4L2_CID_STATELESS_H264_PPS, &pps, sizeof(pps));
+	if (rc < 0)
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+
+	rc = v4l2_set_control(driver_data->video_fd, surface->request_fd,
+			      V4L2_CID_STATELESS_H264_SPS, &sps, sizeof(sps));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 

--- a/src/h265.c
+++ b/src/h265.c
@@ -270,7 +270,13 @@ static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
 
 	memset(slice_params, 0, sizeof(*slice_params));
 
-	slice_params->bit_size = slice->slice_data_size * 8;
+	/*
+	 * bit_size covers the slice data payload located after
+	 * data_byte_offset (the driver checks that offset + size fits
+	 * within the queued buffer).
+	 */
+	slice_params->bit_size = (slice->slice_data_size -
+				  slice->slice_data_byte_offset) * 8;
 	slice_params->data_byte_offset =
 		slice->slice_data_offset + slice->slice_data_byte_offset;
 	slice_params->num_entry_point_offsets = slice->num_entry_point_offsets;

--- a/src/h265.c
+++ b/src/h265.c
@@ -299,7 +299,7 @@ static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
 			num_rps_poc_st_curr_after++;
 		} else if ((hevc_picture->flags & VA_PICTURE_HEVC_RPS_LT_CURR) != 0) {
 			slice_params->dpb[i].rps =
-				V4L2_HEVC_DPB_ENTRY_RPS_LT_CURR;
+				V4L2_HEVC_DPB_ENTRIES_NUM_MAX;
 			num_rps_poc_lt_curr++;
 		}
 
@@ -383,14 +383,14 @@ int h265_set_controls(struct request_data *driver_data,
 	h265_fill_pps(picture, slice, &pps);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_HEVC_PPS, &pps, sizeof(pps));
+			      V4L2_CID_MPEG_VIDEO_DEC_PTS, &pps, sizeof(pps));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	h265_fill_sps(picture, &sps);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_HEVC_SPS, &sps, sizeof(sps));
+			      V4L2_CID_MPEG_VIDEO_DEC_PTS, &sps, sizeof(sps));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
@@ -398,7 +398,7 @@ int h265_set_controls(struct request_data *driver_data,
 			       surface_object->source_data, &slice_params);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_HEVC_SLICE_PARAMS,
+			      V4L2_CID_MPEG_VIDEO_HEVC_TIER,
 			      &slice_params, sizeof(slice_params));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;

--- a/src/h265.c
+++ b/src/h265.c
@@ -36,7 +36,7 @@
 #include <sys/mman.h>
 
 #include <linux/videodev2.h>
-#include <hevc-ctrls.h>
+#include <linux/v4l2-controls.h>
 
 #include "v4l2.h"
 
@@ -51,54 +51,72 @@ static void h265_fill_pps(VAPictureParameterBufferHEVC *picture,
 {
 	memset(pps, 0, sizeof(*pps));
 
-	pps->dependent_slice_segment_flag =
-		slice->LongSliceFlags.fields.dependent_slice_segment_flag;
-	pps->output_flag_present_flag =
-		picture->slice_parsing_fields.bits.output_flag_present_flag;
 	pps->num_extra_slice_header_bits =
 		picture->num_extra_slice_header_bits;
-	pps->sign_data_hiding_enabled_flag =
-		picture->pic_fields.bits.sign_data_hiding_enabled_flag;
-	pps->cabac_init_present_flag =
-		picture->slice_parsing_fields.bits.cabac_init_present_flag;
 	pps->init_qp_minus26 = picture->init_qp_minus26;
-	pps->constrained_intra_pred_flag =
-		picture->pic_fields.bits.constrained_intra_pred_flag;
-	pps->transform_skip_enabled_flag =
-		picture->pic_fields.bits.transform_skip_enabled_flag;
-	pps->cu_qp_delta_enabled_flag =
-		picture->pic_fields.bits.cu_qp_delta_enabled_flag;
 	pps->diff_cu_qp_delta_depth = picture->diff_cu_qp_delta_depth;
 	pps->pps_cb_qp_offset = picture->pps_cb_qp_offset;
 	pps->pps_cr_qp_offset = picture->pps_cr_qp_offset;
-	pps->pps_slice_chroma_qp_offsets_present_flag =
-		picture->slice_parsing_fields.bits.pps_slice_chroma_qp_offsets_present_flag;
-	pps->weighted_pred_flag =
-		picture->pic_fields.bits.weighted_pred_flag;
-	pps->weighted_bipred_flag =
-		picture->pic_fields.bits.weighted_bipred_flag;
-	pps->transquant_bypass_enabled_flag =
-		picture->pic_fields.bits.transquant_bypass_enabled_flag;
-	pps->tiles_enabled_flag =
-		picture->pic_fields.bits.tiles_enabled_flag;
-	pps->entropy_coding_sync_enabled_flag =
-		picture->pic_fields.bits.entropy_coding_sync_enabled_flag;
 	pps->num_tile_columns_minus1 = picture->num_tile_columns_minus1;
 	pps->num_tile_rows_minus1 = picture->num_tile_rows_minus1;
-	pps->loop_filter_across_tiles_enabled_flag =
-		picture->pic_fields.bits.loop_filter_across_tiles_enabled_flag;
-	pps->pps_loop_filter_across_slices_enabled_flag =
-		picture->pic_fields.bits.pps_loop_filter_across_slices_enabled_flag;
-	pps->deblocking_filter_override_enabled_flag =
-		picture->slice_parsing_fields.bits.deblocking_filter_override_enabled_flag;
-	pps->pps_disable_deblocking_filter_flag =
-		picture->slice_parsing_fields.bits.pps_disable_deblocking_filter_flag;
 	pps->pps_beta_offset_div2 = picture->pps_beta_offset_div2;
 	pps->pps_tc_offset_div2 = picture->pps_tc_offset_div2;
-	pps->lists_modification_present_flag =
-		picture->slice_parsing_fields.bits.lists_modification_present_flag;
 	pps->log2_parallel_merge_level_minus2 =
 		picture->log2_parallel_merge_level_minus2;
+
+	if (picture->pic_fields.bits.tiles_enabled_flag) {
+		unsigned int i;
+
+		for (i = 0; i <= picture->num_tile_columns_minus1 && i < 20; i++)
+			pps->column_width_minus1[i] =
+				picture->column_width_minus1[i];
+
+		for (i = 0; i <= picture->num_tile_rows_minus1 && i < 22; i++)
+			pps->row_height_minus1[i] =
+				picture->row_height_minus1[i];
+	}
+
+	if (picture->slice_parsing_fields.bits.dependent_slice_segments_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_DEPENDENT_SLICE_SEGMENT_ENABLED;
+	if (picture->slice_parsing_fields.bits.output_flag_present_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_OUTPUT_FLAG_PRESENT;
+	if (picture->pic_fields.bits.sign_data_hiding_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_SIGN_DATA_HIDING_ENABLED;
+	if (picture->slice_parsing_fields.bits.cabac_init_present_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_CABAC_INIT_PRESENT;
+	if (picture->pic_fields.bits.constrained_intra_pred_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_CONSTRAINED_INTRA_PRED;
+	if (picture->pic_fields.bits.transform_skip_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_TRANSFORM_SKIP_ENABLED;
+	if (picture->pic_fields.bits.cu_qp_delta_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_CU_QP_DELTA_ENABLED;
+	if (picture->slice_parsing_fields.bits.pps_slice_chroma_qp_offsets_present_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT;
+	if (picture->pic_fields.bits.weighted_pred_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_WEIGHTED_PRED;
+	if (picture->pic_fields.bits.weighted_bipred_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_WEIGHTED_BIPRED;
+	if (picture->pic_fields.bits.transquant_bypass_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_TRANSQUANT_BYPASS_ENABLED;
+	if (picture->pic_fields.bits.tiles_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_TILES_ENABLED;
+	if (picture->pic_fields.bits.entropy_coding_sync_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_ENTROPY_CODING_SYNC_ENABLED;
+	if (picture->pic_fields.bits.loop_filter_across_tiles_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_LOOP_FILTER_ACROSS_TILES_ENABLED;
+	if (picture->pic_fields.bits.pps_loop_filter_across_slices_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED;
+	if (picture->slice_parsing_fields.bits.deblocking_filter_override_enabled_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_DEBLOCKING_FILTER_OVERRIDE_ENABLED;
+	if (picture->slice_parsing_fields.bits.pps_disable_deblocking_filter_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_PPS_DISABLE_DEBLOCKING_FILTER;
+	if (picture->slice_parsing_fields.bits.lists_modification_present_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_LISTS_MODIFICATION_PRESENT;
+	if (picture->slice_parsing_fields.bits.slice_segment_header_extension_present_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_SLICE_SEGMENT_HEADER_EXTENSION_PRESENT;
+	if (picture->slice_parsing_fields.bits.deblocking_filter_override_enabled_flag ||
+	    !picture->slice_parsing_fields.bits.pps_disable_deblocking_filter_flag)
+		pps->flags |= V4L2_HEVC_PPS_FLAG_DEBLOCKING_FILTER_CONTROL_PRESENT;
 }
 
 static void h265_fill_sps(VAPictureParameterBufferHEVC *picture,
@@ -107,8 +125,6 @@ static void h265_fill_sps(VAPictureParameterBufferHEVC *picture,
 	memset(sps, 0, sizeof(*sps));
 
 	sps->chroma_format_idc = picture->pic_fields.bits.chroma_format_idc;
-	sps->separate_colour_plane_flag =
-		picture->pic_fields.bits.separate_colour_plane_flag;
 	sps->pic_width_in_luma_samples = picture->pic_width_in_luma_samples;
 	sps->pic_height_in_luma_samples = picture->pic_height_in_luma_samples;
 	sps->bit_depth_luma_minus8 = picture->bit_depth_luma_minus8;
@@ -131,12 +147,6 @@ static void h265_fill_sps(VAPictureParameterBufferHEVC *picture,
 		picture->max_transform_hierarchy_depth_inter;
 	sps->max_transform_hierarchy_depth_intra =
 		picture->max_transform_hierarchy_depth_intra;
-	sps->scaling_list_enabled_flag =
-		picture->pic_fields.bits.scaling_list_enabled_flag;
-	sps->amp_enabled_flag = picture->pic_fields.bits.amp_enabled_flag;
-	sps->sample_adaptive_offset_enabled_flag =
-		picture->slice_parsing_fields.bits.sample_adaptive_offset_enabled_flag;
-	sps->pcm_enabled_flag = picture->pic_fields.bits.pcm_enabled_flag;
 	sps->pcm_sample_bit_depth_luma_minus1 =
 		picture->pcm_sample_bit_depth_luma_minus1;
 	sps->pcm_sample_bit_depth_chroma_minus1 =
@@ -145,133 +155,49 @@ static void h265_fill_sps(VAPictureParameterBufferHEVC *picture,
 		picture->log2_min_pcm_luma_coding_block_size_minus3;
 	sps->log2_diff_max_min_pcm_luma_coding_block_size =
 		picture->log2_diff_max_min_pcm_luma_coding_block_size;
-	sps->pcm_loop_filter_disabled_flag =
-		picture->pic_fields.bits.pcm_loop_filter_disabled_flag;
 	sps->num_short_term_ref_pic_sets = picture->num_short_term_ref_pic_sets;
-	sps->long_term_ref_pics_present_flag =
-		picture->slice_parsing_fields.bits.long_term_ref_pics_present_flag;
 	sps->num_long_term_ref_pics_sps = picture->num_long_term_ref_pic_sps;
-	sps->sps_temporal_mvp_enabled_flag =
-		picture->slice_parsing_fields.bits.sps_temporal_mvp_enabled_flag;
-	sps->strong_intra_smoothing_enabled_flag =
-		picture->pic_fields.bits.strong_intra_smoothing_enabled_flag;
+
+	if (picture->pic_fields.bits.separate_colour_plane_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_SEPARATE_COLOUR_PLANE;
+	if (picture->pic_fields.bits.scaling_list_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_SCALING_LIST_ENABLED;
+	if (picture->pic_fields.bits.amp_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_AMP_ENABLED;
+	if (picture->slice_parsing_fields.bits.sample_adaptive_offset_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_SAMPLE_ADAPTIVE_OFFSET;
+	if (picture->pic_fields.bits.pcm_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_PCM_ENABLED;
+	if (picture->pic_fields.bits.pcm_loop_filter_disabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_PCM_LOOP_FILTER_DISABLED;
+	if (picture->slice_parsing_fields.bits.long_term_ref_pics_present_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_LONG_TERM_REF_PICS_PRESENT;
+	if (picture->slice_parsing_fields.bits.sps_temporal_mvp_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_SPS_TEMPORAL_MVP_ENABLED;
+	if (picture->pic_fields.bits.strong_intra_smoothing_enabled_flag)
+		sps->flags |= V4L2_HEVC_SPS_FLAG_STRONG_INTRA_SMOOTHING_ENABLED;
 }
 
-static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
-				   VASliceParameterBufferHEVC *slice,
-				   struct object_heap *surface_heap,
-				   void *source_data,
-				   struct v4l2_ctrl_hevc_slice_params *slice_params)
+static void h265_fill_decode_params(VAPictureParameterBufferHEVC *picture,
+				    VASliceParameterBufferHEVC *slice,
+				    struct object_heap *surface_heap,
+				    struct v4l2_ctrl_hevc_decode_params *decode_params)
 {
 	struct object_surface *surface_object;
 	VAPictureHEVC *hevc_picture;
-	uint8_t nal_unit_type;
-	uint8_t nuh_temporal_id_plus1;
-	uint32_t data_bit_offset;
-	uint8_t pic_struct;
-	uint8_t field_pic;
-	uint8_t slice_type;
-	unsigned int num_active_dpb_entries;
-	unsigned int num_rps_poc_st_curr_before;
-	unsigned int num_rps_poc_st_curr_after;
-	unsigned int num_rps_poc_lt_curr;
-	uint8_t *b;
-	unsigned int count;
-	unsigned int o, i, j;
+	uint8_t num_active_dpb_entries = 0;
+	uint8_t num_poc_st_curr_before = 0;
+	uint8_t num_poc_st_curr_after = 0;
+	uint8_t num_poc_lt_curr = 0;
+	unsigned int i;
 
-	/* Extract the missing NAL header information. */
+	memset(decode_params, 0, sizeof(*decode_params));
 
-	b = source_data + slice->slice_data_offset;
+	decode_params->pic_order_cnt_val = picture->CurrPic.pic_order_cnt;
+	decode_params->short_term_ref_pic_set_size = picture->st_rps_bits;
 
-	nal_unit_type = (b[0] >> H265_NAL_UNIT_TYPE_SHIFT) &
-			H265_NAL_UNIT_TYPE_MASK;
-	nuh_temporal_id_plus1 = (b[1] >> H265_NUH_TEMPORAL_ID_PLUS1_SHIFT) &
-				H265_NUH_TEMPORAL_ID_PLUS1_MASK;
-
-	/*
-	 * VAAPI only provides a byte-aligned value for the slice segment data
-	 * offset, although it appears that the offset is not always aligned.
-	 * Search for the first one bit in the previous byte, that marks the
-	 * start of the slice segment to correct the value.
-	 */
-
-	b = source_data + (slice->slice_data_offset +
-			   slice->slice_data_byte_offset) - 1;
-
-	for (o = 0; o < 8; o++)
-		if (*b & (1 << o))
-			break;
-
-	/* Include the one bit. */
-	o++;
-
-	data_bit_offset = (slice->slice_data_offset +
-			   slice->slice_data_byte_offset) * 8 - o;
-
-	memset(slice_params, 0, sizeof(*slice_params));
-
-	slice_params->bit_size = slice->slice_data_size * 8;
-	slice_params->data_bit_offset = data_bit_offset;
-	slice_params->nal_unit_type = nal_unit_type;
-	slice_params->nuh_temporal_id_plus1 = nuh_temporal_id_plus1;
-
-	slice_type = slice->LongSliceFlags.fields.slice_type;
-
-	slice_params->slice_type = slice_type,
-	slice_params->colour_plane_id =
-		slice->LongSliceFlags.fields.color_plane_id;
-	slice_params->slice_pic_order_cnt =
-		picture->CurrPic.pic_order_cnt;
-	slice_params->slice_sao_luma_flag =
-		slice->LongSliceFlags.fields.slice_sao_luma_flag;
-	slice_params->slice_sao_chroma_flag =
-		slice->LongSliceFlags.fields.slice_sao_chroma_flag;
-	slice_params->slice_temporal_mvp_enabled_flag =
-		slice->LongSliceFlags.fields.slice_temporal_mvp_enabled_flag;
-	slice_params->num_ref_idx_l0_active_minus1 =
-		slice->num_ref_idx_l0_active_minus1;
-	slice_params->num_ref_idx_l1_active_minus1 =
-		slice->num_ref_idx_l1_active_minus1;
-	slice_params->mvd_l1_zero_flag =
-		slice->LongSliceFlags.fields.mvd_l1_zero_flag;
-	slice_params->cabac_init_flag =
-		slice->LongSliceFlags.fields.cabac_init_flag;
-	slice_params->collocated_from_l0_flag =
-		slice->LongSliceFlags.fields.collocated_from_l0_flag;
-	slice_params->collocated_ref_idx = slice->collocated_ref_idx;
-	slice_params->five_minus_max_num_merge_cand =
-		slice->five_minus_max_num_merge_cand;
-	slice_params->use_integer_mv_flag = 0;
-	slice_params->slice_qp_delta = slice->slice_qp_delta;
-	slice_params->slice_cb_qp_offset = slice->slice_cb_qp_offset;
-	slice_params->slice_cr_qp_offset = slice->slice_cr_qp_offset;
-	slice_params->slice_act_y_qp_offset = 0;
-	slice_params->slice_act_cb_qp_offset = 0;
-	slice_params->slice_act_cr_qp_offset = 0;
-	slice_params->slice_deblocking_filter_disabled_flag =
-		slice->LongSliceFlags.fields.slice_deblocking_filter_disabled_flag;
-	slice_params->slice_beta_offset_div2 = slice->slice_beta_offset_div2;
-	slice_params->slice_tc_offset_div2 = slice->slice_tc_offset_div2;
-	slice_params->slice_loop_filter_across_slices_enabled_flag =
-		slice->LongSliceFlags.fields.slice_loop_filter_across_slices_enabled_flag;
-
-	if (picture->CurrPic.flags & VA_PICTURE_HEVC_FIELD_PIC) {
-		if (picture->CurrPic.flags & VA_PICTURE_HEVC_BOTTOM_FIELD)
-			pic_struct = 2;
-		else
-			pic_struct = 1;
-	} else {
-		pic_struct = 0;
-	}
-
-	slice_params->pic_struct = pic_struct;
-
-	num_active_dpb_entries = 0;
-	num_rps_poc_st_curr_before = 0;
-	num_rps_poc_st_curr_after = 0;
-	num_rps_poc_lt_curr = 0;
-
-	for (i = 0; i < 15 && slice_type != V4L2_HEVC_SLICE_TYPE_I ; i++) {
+	for (i = 0; i < 15 && i < V4L2_HEVC_DPB_ENTRIES_NUM_MAX; i++) {
+		struct v4l2_hevc_dpb_entry *dpb = &decode_params->dpb[i];
 		uint64_t timestamp;
 
 		hevc_picture = &picture->ReferenceFrames[i];
@@ -287,34 +213,129 @@ static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
 			break;
 
 		timestamp = v4l2_timeval_to_ns(&surface_object->timestamp);
-		slice_params->dpb[i].timestamp = timestamp;
+		dpb->timestamp = timestamp;
+		dpb->field_pic =
+			!!(hevc_picture->flags & VA_PICTURE_HEVC_FIELD_PIC);
+		/* TODO: Interlaced: get the POC for each field. */
+		dpb->pic_order_cnt_val = hevc_picture->pic_order_cnt;
 
-		if ((hevc_picture->flags & VA_PICTURE_HEVC_RPS_ST_CURR_BEFORE) != 0) {
-			slice_params->dpb[i].rps =
-				V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_BEFORE;
-			num_rps_poc_st_curr_before++;
-		} else if ((hevc_picture->flags & VA_PICTURE_HEVC_RPS_ST_CURR_AFTER) != 0) {
-			slice_params->dpb[i].rps =
-				V4L2_HEVC_DPB_ENTRY_RPS_ST_CURR_AFTER;
-			num_rps_poc_st_curr_after++;
-		} else if ((hevc_picture->flags & VA_PICTURE_HEVC_RPS_LT_CURR) != 0) {
-			slice_params->dpb[i].rps =
-				V4L2_HEVC_DPB_ENTRIES_NUM_MAX;
-			num_rps_poc_lt_curr++;
-		}
+		if (hevc_picture->flags & VA_PICTURE_HEVC_LONG_TERM_REFERENCE)
+			dpb->flags |= V4L2_HEVC_DPB_ENTRY_LONG_TERM_REFERENCE;
 
-		field_pic = !!(hevc_picture->flags & VA_PICTURE_HEVC_FIELD_PIC);
-
-		slice_params->dpb[i].field_pic = field_pic;
-
-		/* TODO: Interleaved: Get the POC for each field. */
-		slice_params->dpb[i].pic_order_cnt[0] =
-			hevc_picture->pic_order_cnt;
+		if (hevc_picture->flags & VA_PICTURE_HEVC_RPS_ST_CURR_BEFORE)
+			decode_params->poc_st_curr_before[num_poc_st_curr_before++] = i;
+		else if (hevc_picture->flags & VA_PICTURE_HEVC_RPS_ST_CURR_AFTER)
+			decode_params->poc_st_curr_after[num_poc_st_curr_after++] = i;
+		else if (hevc_picture->flags & VA_PICTURE_HEVC_RPS_LT_CURR)
+			decode_params->poc_lt_curr[num_poc_lt_curr++] = i;
 
 		num_active_dpb_entries++;
 	}
 
-	slice_params->num_active_dpb_entries = num_active_dpb_entries;
+	decode_params->num_active_dpb_entries = num_active_dpb_entries;
+	decode_params->num_poc_st_curr_before = num_poc_st_curr_before;
+	decode_params->num_poc_st_curr_after = num_poc_st_curr_after;
+	decode_params->num_poc_lt_curr = num_poc_lt_curr;
+
+	if (picture->slice_parsing_fields.bits.IdrPicFlag)
+		decode_params->flags |= V4L2_HEVC_DECODE_PARAM_FLAG_IDR_PIC;
+	if (picture->slice_parsing_fields.bits.RapPicFlag)
+		decode_params->flags |= V4L2_HEVC_DECODE_PARAM_FLAG_IRAP_PIC;
+	if (picture->pic_fields.bits.NoPicReorderingFlag)
+		decode_params->flags |= V4L2_HEVC_DECODE_PARAM_FLAG_NO_OUTPUT_OF_PRIOR;
+}
+
+static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
+				   VASliceParameterBufferHEVC *slice,
+				   struct object_heap *surface_heap,
+				   void *source_data,
+				   struct v4l2_ctrl_hevc_slice_params *slice_params)
+{
+	uint8_t nal_unit_type;
+	uint8_t nuh_temporal_id_plus1;
+	uint8_t pic_struct;
+	uint8_t slice_type;
+	uint8_t *b;
+	unsigned int count;
+	unsigned int i, j;
+
+	/* Extract the missing NAL header information. */
+
+	b = source_data + slice->slice_data_offset;
+
+	nal_unit_type = (b[0] >> H265_NAL_UNIT_TYPE_SHIFT) &
+			H265_NAL_UNIT_TYPE_MASK;
+	nuh_temporal_id_plus1 = (b[1] >> H265_NUH_TEMPORAL_ID_PLUS1_SHIFT) &
+				H265_NUH_TEMPORAL_ID_PLUS1_MASK;
+
+	memset(slice_params, 0, sizeof(*slice_params));
+
+	slice_params->bit_size = slice->slice_data_size * 8;
+	slice_params->data_byte_offset =
+		slice->slice_data_offset + slice->slice_data_byte_offset;
+	slice_params->num_entry_point_offsets = slice->num_entry_point_offsets;
+	slice_params->nal_unit_type = nal_unit_type;
+	slice_params->nuh_temporal_id_plus1 = nuh_temporal_id_plus1;
+
+	slice_type = slice->LongSliceFlags.fields.slice_type;
+
+	slice_params->slice_type = slice_type;
+	slice_params->colour_plane_id =
+		slice->LongSliceFlags.fields.color_plane_id;
+	slice_params->slice_pic_order_cnt =
+		picture->CurrPic.pic_order_cnt;
+	slice_params->num_ref_idx_l0_active_minus1 =
+		slice->num_ref_idx_l0_active_minus1;
+	slice_params->num_ref_idx_l1_active_minus1 =
+		slice->num_ref_idx_l1_active_minus1;
+	slice_params->collocated_ref_idx = slice->collocated_ref_idx;
+	slice_params->five_minus_max_num_merge_cand =
+		slice->five_minus_max_num_merge_cand;
+	slice_params->slice_qp_delta = slice->slice_qp_delta;
+	slice_params->slice_cb_qp_offset = slice->slice_cb_qp_offset;
+	slice_params->slice_cr_qp_offset = slice->slice_cr_qp_offset;
+	slice_params->slice_act_y_qp_offset = 0;
+	slice_params->slice_act_cb_qp_offset = 0;
+	slice_params->slice_act_cr_qp_offset = 0;
+	slice_params->slice_beta_offset_div2 = slice->slice_beta_offset_div2;
+	slice_params->slice_tc_offset_div2 = slice->slice_tc_offset_div2;
+	slice_params->slice_segment_addr = slice->slice_segment_address;
+	slice_params->short_term_ref_pic_set_size = picture->st_rps_bits;
+
+	if (slice->LongSliceFlags.fields.slice_sao_luma_flag)
+		slice_params->flags |= V4L2_HEVC_SLICE_PARAMS_FLAG_SLICE_SAO_LUMA;
+	if (slice->LongSliceFlags.fields.slice_sao_chroma_flag)
+		slice_params->flags |= V4L2_HEVC_SLICE_PARAMS_FLAG_SLICE_SAO_CHROMA;
+	if (slice->LongSliceFlags.fields.slice_temporal_mvp_enabled_flag)
+		slice_params->flags |=
+			V4L2_HEVC_SLICE_PARAMS_FLAG_SLICE_TEMPORAL_MVP_ENABLED;
+	if (slice->LongSliceFlags.fields.mvd_l1_zero_flag)
+		slice_params->flags |= V4L2_HEVC_SLICE_PARAMS_FLAG_MVD_L1_ZERO;
+	if (slice->LongSliceFlags.fields.cabac_init_flag)
+		slice_params->flags |= V4L2_HEVC_SLICE_PARAMS_FLAG_CABAC_INIT;
+	if (slice->LongSliceFlags.fields.collocated_from_l0_flag)
+		slice_params->flags |=
+			V4L2_HEVC_SLICE_PARAMS_FLAG_COLLOCATED_FROM_L0;
+	if (slice->LongSliceFlags.fields.slice_deblocking_filter_disabled_flag)
+		slice_params->flags |=
+			V4L2_HEVC_SLICE_PARAMS_FLAG_SLICE_DEBLOCKING_FILTER_DISABLED;
+	if (slice->LongSliceFlags.fields.slice_loop_filter_across_slices_enabled_flag)
+		slice_params->flags |=
+			V4L2_HEVC_SLICE_PARAMS_FLAG_SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED;
+	if (slice->LongSliceFlags.fields.dependent_slice_segment_flag)
+		slice_params->flags |=
+			V4L2_HEVC_SLICE_PARAMS_FLAG_DEPENDENT_SLICE_SEGMENT;
+
+	if (picture->CurrPic.flags & VA_PICTURE_HEVC_FIELD_PIC) {
+		if (picture->CurrPic.flags & VA_PICTURE_HEVC_BOTTOM_FIELD)
+			pic_struct = V4L2_HEVC_SEI_PIC_STRUCT_BOTTOM_FIELD;
+		else
+			pic_struct = V4L2_HEVC_SEI_PIC_STRUCT_TOP_FIELD;
+	} else {
+		pic_struct = V4L2_HEVC_SEI_PIC_STRUCT_FRAME;
+	}
+
+	slice_params->pic_struct = pic_struct;
 
 	count = slice_params->num_ref_idx_l0_active_minus1 + 1;
 
@@ -323,12 +344,8 @@ static void h265_fill_slice_params(VAPictureParameterBufferHEVC *picture,
 
 	count = slice_params->num_ref_idx_l1_active_minus1 + 1;
 
-	for (i = 0; i < count && slice_type == V4L2_HEVC_SLICE_TYPE_B ; i++)
+	for (i = 0; i < count && slice_type == V4L2_HEVC_SLICE_TYPE_B; i++)
 		slice_params->ref_idx_l1[i] = slice->RefPicList[1][i];
-
-	slice_params->num_rps_poc_st_curr_before = num_rps_poc_st_curr_before;
-	slice_params->num_rps_poc_st_curr_after = num_rps_poc_st_curr_after;
-	slice_params->num_rps_poc_lt_curr = num_rps_poc_lt_curr;
 
 	slice_params->pred_weight_table.luma_log2_weight_denom =
 		slice->luma_log2_weight_denom;
@@ -372,25 +389,32 @@ int h265_set_controls(struct request_data *driver_data,
 		&surface_object->params.h265.picture;
 	VASliceParameterBufferHEVC *slice =
 		&surface_object->params.h265.slice;
-	VAIQMatrixBufferHEVC *iqmatrix =
-		&surface_object->params.h265.iqmatrix;
-	bool iqmatrix_set = surface_object->params.h265.iqmatrix_set;
 	struct v4l2_ctrl_hevc_pps pps;
 	struct v4l2_ctrl_hevc_sps sps;
+	struct v4l2_ctrl_hevc_decode_params decode_params;
 	struct v4l2_ctrl_hevc_slice_params slice_params;
 	int rc;
-
-	h265_fill_pps(picture, slice, &pps);
-
-	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_DEC_PTS, &pps, sizeof(pps));
-	if (rc < 0)
-		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	h265_fill_sps(picture, &sps);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_DEC_PTS, &sps, sizeof(sps));
+			      V4L2_CID_STATELESS_HEVC_SPS, &sps, sizeof(sps));
+	if (rc < 0)
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+
+	h265_fill_pps(picture, slice, &pps);
+
+	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
+			      V4L2_CID_STATELESS_HEVC_PPS, &pps, sizeof(pps));
+	if (rc < 0)
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+
+	h265_fill_decode_params(picture, slice, &driver_data->surface_heap,
+				&decode_params);
+
+	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
+			      V4L2_CID_STATELESS_HEVC_DECODE_PARAMS,
+			      &decode_params, sizeof(decode_params));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
@@ -398,7 +422,7 @@ int h265_set_controls(struct request_data *driver_data,
 			       surface_object->source_data, &slice_params);
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_HEVC_TIER,
+			      V4L2_CID_STATELESS_HEVC_SLICE_PARAMS,
 			      &slice_params, sizeof(slice_params));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;

--- a/src/image.c
+++ b/src/image.c
@@ -155,7 +155,22 @@ static VAStatus copy_surface_to_image (struct request_data *driver_data,
 		return VA_STATUS_ERROR_INVALID_BUFFER;
 
 	for (i = 0; i < surface_object->destination_planes_count; i++) {
-		if (!video_format_is_linear(driver_data->video_format))
+		if (driver_data->video_format->v4l2_format ==
+		    V4L2_PIX_FMT_NV12M_COL128) {
+			unsigned int columns_count =
+				(surface_object->destination_bytesperlines[i] +
+				 127) / 128;
+			unsigned int col_stride =
+				surface_object->destination_sizes[i] /
+				columns_count;
+
+			sand_to_planar(surface_object->destination_data[i],
+				       buffer_object->data + image->offsets[i],
+				       image->pitches[i], col_stride,
+				       image->width,
+				       i == 0 ? image->height :
+						image->height / 2);
+		} else if (!video_format_is_linear(driver_data->video_format))
 			tiled_to_planar(surface_object->destination_data[i],
 					buffer_object->data + image->offsets[i],
 					image->pitches[i], image->width,

--- a/src/meson.build
+++ b/src/meson.build
@@ -39,6 +39,7 @@ sources = [
 	'image.c',
 	'utils.c',
 	'tiled_yuv.S',
+	'tiled_yuv.c',
 	'video.c',
 	'media.c',
 	'v4l2.c',

--- a/src/mpeg2.c
+++ b/src/mpeg2.c
@@ -35,7 +35,7 @@
 #include <sys/mman.h>
 
 #include <linux/videodev2.h>
-#include <mpeg2-ctrls.h>
+#include <linux/v4l2-controls.h>
 
 #include "v4l2.h"
 
@@ -45,61 +45,55 @@ int mpeg2_set_controls(struct request_data *driver_data,
 {
 	VAPictureParameterBufferMPEG2 *picture =
 		&surface_object->params.mpeg2.picture;
-	VASliceParameterBufferMPEG2 *slice =
-		&surface_object->params.mpeg2.slice;
 	VAIQMatrixBufferMPEG2 *iqmatrix =
 		&surface_object->params.mpeg2.iqmatrix;
 	bool iqmatrix_set = surface_object->params.mpeg2.iqmatrix_set;
-	struct v4l2_ctrl_mpeg2_slice_params slice_params;
-	struct v4l2_ctrl_mpeg2_quantization quantization;
+	struct v4l2_ctrl_mpeg2_sequence sequence;
+	struct v4l2_ctrl_mpeg2_picture pic;
+	struct v4l2_ctrl_mpeg2_quantisation quantisation;
 	struct object_surface *forward_reference_surface;
 	struct object_surface *backward_reference_surface;
 	uint64_t timestamp;
 	unsigned int i;
 	int rc;
 
-	memset(&slice_params, 0, sizeof(slice_params));
+	memset(&sequence, 0, sizeof(sequence));
 
-	slice_params.bit_size = surface_object->slices_size * 8;
-	slice_params.data_bit_offset = 0;
+	sequence.horizontal_size = picture->horizontal_size;
+	sequence.vertical_size = picture->vertical_size;
+	sequence.vbv_buffer_size = SOURCE_SIZE_MAX;
+	sequence.profile_and_level_indication = 0;
+	sequence.chroma_format = 1; // 4:2:0
 
-	slice_params.sequence.horizontal_size = picture->horizontal_size;
-	slice_params.sequence.vertical_size = picture->vertical_size;
-	slice_params.sequence.vbv_buffer_size = SOURCE_SIZE_MAX;
+	memset(&pic, 0, sizeof(pic));
 
-	slice_params.sequence.profile_and_level_indication = 0;
-	slice_params.sequence.progressive_sequence = 0;
-	slice_params.sequence.chroma_format = 1; // 4:2:0
+	pic.picture_coding_type = picture->picture_coding_type;
+	pic.f_code[0][0] = (picture->f_code >> 12) & 0x0f;
+	pic.f_code[0][1] = (picture->f_code >> 8) & 0x0f;
+	pic.f_code[1][0] = (picture->f_code >> 4) & 0x0f;
+	pic.f_code[1][1] = (picture->f_code >> 0) & 0x0f;
 
-	slice_params.picture.picture_coding_type = picture->picture_coding_type;
-	slice_params.picture.f_code[0][0] = (picture->f_code >> 12) & 0x0f;
-	slice_params.picture.f_code[0][1] = (picture->f_code >> 8) & 0x0f;
-	slice_params.picture.f_code[1][0] = (picture->f_code >> 4) & 0x0f;
-	slice_params.picture.f_code[1][1] = (picture->f_code >> 0) & 0x0f;
-
-	slice_params.picture.intra_dc_precision =
+	pic.intra_dc_precision =
 		picture->picture_coding_extension.bits.intra_dc_precision;
-	slice_params.picture.picture_structure =
+	pic.picture_structure =
 		picture->picture_coding_extension.bits.picture_structure;
-	slice_params.picture.top_field_first =
-		picture->picture_coding_extension.bits.top_field_first;
-	slice_params.picture.frame_pred_frame_dct =
-		picture->picture_coding_extension.bits.frame_pred_frame_dct;
-	slice_params.picture.concealment_motion_vectors =
-		picture->picture_coding_extension.bits
-			.concealment_motion_vectors;
-	slice_params.picture.q_scale_type =
-		picture->picture_coding_extension.bits.q_scale_type;
-	slice_params.picture.intra_vlc_format =
-		picture->picture_coding_extension.bits.intra_vlc_format;
-	slice_params.picture.alternate_scan =
-		picture->picture_coding_extension.bits.alternate_scan;
-	slice_params.picture.repeat_first_field =
-		picture->picture_coding_extension.bits.repeat_first_field;
-	slice_params.picture.progressive_frame =
-		picture->picture_coding_extension.bits.progressive_frame;
 
-	slice_params.quantiser_scale_code = slice->quantiser_scale_code;
+	if (picture->picture_coding_extension.bits.top_field_first)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_TOP_FIELD_FIRST;
+	if (picture->picture_coding_extension.bits.frame_pred_frame_dct)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_FRAME_PRED_DCT;
+	if (picture->picture_coding_extension.bits.concealment_motion_vectors)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_CONCEALMENT_MV;
+	if (picture->picture_coding_extension.bits.q_scale_type)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_Q_SCALE_TYPE;
+	if (picture->picture_coding_extension.bits.intra_vlc_format)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_INTRA_VLC;
+	if (picture->picture_coding_extension.bits.alternate_scan)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_ALT_SCAN;
+	if (picture->picture_coding_extension.bits.repeat_first_field)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_REPEAT_FIRST;
+	if (picture->picture_coding_extension.bits.progressive_frame)
+		pic.flags |= V4L2_MPEG2_PIC_FLAG_PROGRESSIVE;
 
 	forward_reference_surface =
 		SURFACE(driver_data, picture->forward_reference_picture);
@@ -107,7 +101,7 @@ int mpeg2_set_controls(struct request_data *driver_data,
 		forward_reference_surface = surface_object;
 
 	timestamp = v4l2_timeval_to_ns(&forward_reference_surface->timestamp);
-	slice_params.forward_ref_ts = timestamp;
+	pic.forward_ref_ts = timestamp;
 
 	backward_reference_surface =
 		SURFACE(driver_data, picture->backward_reference_picture);
@@ -115,39 +109,40 @@ int mpeg2_set_controls(struct request_data *driver_data,
 		backward_reference_surface = surface_object;
 
 	timestamp = v4l2_timeval_to_ns(&backward_reference_surface->timestamp);
-	slice_params.backward_ref_ts = timestamp;
+	pic.backward_ref_ts = timestamp;
 
 	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
-			      V4L2_CID_MPEG_VIDEO_MPEG2_SLICE_PARAMS,
-			      &slice_params, sizeof(slice_params));
+			      V4L2_CID_STATELESS_MPEG2_SEQUENCE,
+			      &sequence, sizeof(sequence));
+	if (rc < 0)
+		return VA_STATUS_ERROR_OPERATION_FAILED;
+
+	rc = v4l2_set_control(driver_data->video_fd, surface_object->request_fd,
+			      V4L2_CID_STATELESS_MPEG2_PICTURE,
+			      &pic, sizeof(pic));
 	if (rc < 0)
 		return VA_STATUS_ERROR_OPERATION_FAILED;
 
 	if (iqmatrix_set) {
-		quantization.load_intra_quantiser_matrix =
-			iqmatrix->load_intra_quantiser_matrix;
-		quantization.load_non_intra_quantiser_matrix =
-			iqmatrix->load_non_intra_quantiser_matrix;
-		quantization.load_chroma_intra_quantiser_matrix =
-			iqmatrix->load_chroma_intra_quantiser_matrix;
-		quantization.load_chroma_non_intra_quantiser_matrix =
-			iqmatrix->load_chroma_non_intra_quantiser_matrix;
+		memset(&quantisation, 0, sizeof(quantisation));
 
 		for (i = 0; i < 64; i++) {
-			quantization.intra_quantiser_matrix[i] =
+			quantisation.intra_quantiser_matrix[i] =
 				iqmatrix->intra_quantiser_matrix[i];
-			quantization.non_intra_quantiser_matrix[i] =
+			quantisation.non_intra_quantiser_matrix[i] =
 				iqmatrix->non_intra_quantiser_matrix[i];
-			quantization.chroma_intra_quantiser_matrix[i] =
+			quantisation.chroma_intra_quantiser_matrix[i] =
 				iqmatrix->chroma_intra_quantiser_matrix[i];
-			quantization.chroma_non_intra_quantiser_matrix[i] =
+			quantisation.chroma_non_intra_quantiser_matrix[i] =
 				iqmatrix->chroma_non_intra_quantiser_matrix[i];
 		}
 
 		rc = v4l2_set_control(driver_data->video_fd,
 				      surface_object->request_fd,
-				      V4L2_CID_MPEG_VIDEO_MPEG2_QUANTIZATION,
-				      &quantization, sizeof(quantization));
+				      V4L2_CID_STATELESS_MPEG2_QUANTISATION,
+				      &quantisation, sizeof(quantisation));
+		if (rc < 0)
+			return VA_STATUS_ERROR_OPERATION_FAILED;
 	}
 
 	return 0;

--- a/src/picture.c
+++ b/src/picture.c
@@ -41,6 +41,7 @@
 #include <errno.h>
 
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 
 #include <linux/videodev2.h>
 
@@ -219,6 +220,44 @@ VAStatus RequestBeginPicture(VADriverContextP context, VAContextID context_id,
 
 	if (surface_object->status == VASurfaceRendering)
 		RequestSyncSurface(context, surface_id);
+
+	/*
+	 * Surfaces created after the context (the usual case with modern
+	 * libva clients) have no source buffer yet: attach one from the
+	 * context's pool. Decoding is synchronous, so sharing pool buffers
+	 * between surfaces is safe.
+	 */
+	if (surface_object->source_data == NULL) {
+		struct video_format *video_format = driver_data->video_format;
+		unsigned int output_type;
+		unsigned int length, offset, index;
+		void *source_data;
+		int rc;
+
+		if (video_format == NULL ||
+		    context_object->source_buffers_count == 0)
+			return VA_STATUS_ERROR_OPERATION_FAILED;
+
+		output_type = v4l2_type_video_output(video_format->v4l2_mplane);
+
+		index = context_object->source_index_base +
+			(context_object->source_next++ %
+			 context_object->source_buffers_count);
+
+		rc = v4l2_query_buffer(driver_data->video_fd, output_type,
+				       index, &length, &offset, 1);
+		if (rc < 0)
+			return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
+		source_data = mmap(NULL, length, PROT_READ | PROT_WRITE,
+				   MAP_SHARED, driver_data->video_fd, offset);
+		if (source_data == MAP_FAILED)
+			return VA_STATUS_ERROR_ALLOCATION_FAILED;
+
+		surface_object->source_index = index;
+		surface_object->source_data = source_data;
+		surface_object->source_size = length;
+	}
 
 	surface_object->status = VASurfaceRendering;
 	context_object->render_surface_id = surface_id;

--- a/src/surface.c
+++ b/src/surface.c
@@ -85,6 +85,14 @@ VAStatus RequestCreateSurfaces2(VADriverContextP context, unsigned int format,
 		if (found)
 			video_format = video_format_find(V4L2_PIX_FMT_NV12);
 
+		if (video_format == NULL) {
+			found = v4l2_find_format(driver_data->video_fd,
+						 V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE,
+						 V4L2_PIX_FMT_NV12M_COL128);
+			if (found)
+				video_format = video_format_find(V4L2_PIX_FMT_NV12M_COL128);
+		}
+
 		if (video_format == NULL)
 			return VA_STATUS_ERROR_OPERATION_FAILED;
 

--- a/src/tiled_yuv.c
+++ b/src/tiled_yuv.c
@@ -1,15 +1,20 @@
 /*
- * C fallback implementation of the Sunxi 32x32 tiled NV12 untiling,
- * used on architectures without the NEON assembly version (tiled_yuv.S
- * only builds on 32-bit ARM).
+ * C implementations of tiled-to-linear YUV conversions.
+ *
+ * tiled_to_planar (Sunxi 32x32 tiles) is a fallback used on architectures
+ * without the NEON assembly version (tiled_yuv.S only builds on 32-bit ARM).
+ *
+ * sand_to_planar handles the Broadcom SAND128 layout (used by the Raspberry
+ * Pi HEVC decoder): the plane is stored as columns of 128 bytes, with each
+ * column holding col_stride / 128 consecutive lines.
  */
-
-#ifdef __aarch64__
 
 #include <stdint.h>
 #include <string.h>
 
 #include "tiled_yuv.h"
+
+#ifdef __aarch64__
 
 void tiled_to_planar(void *src, void *dst, unsigned int dst_pitch,
 		     unsigned int width, unsigned int height)
@@ -30,3 +35,21 @@ void tiled_to_planar(void *src, void *dst, unsigned int dst_pitch,
 }
 
 #endif
+
+void sand_to_planar(void *src, void *dst, unsigned int dst_pitch,
+		    unsigned int col_stride, unsigned int width,
+		    unsigned int height)
+{
+	unsigned int i, j;
+
+	for (i = 0; i < height; i++) {
+		for (j = 0; j < width; j += 128) {
+			unsigned int offset = (j / 128) * col_stride + i * 128;
+			unsigned int length = (width - j) < 128 ?
+					      (width - j) : 128;
+
+			memcpy((uint8_t *)dst + i * dst_pitch + j,
+			       (uint8_t *)src + offset, length);
+		}
+	}
+}

--- a/src/tiled_yuv.c
+++ b/src/tiled_yuv.c
@@ -1,0 +1,32 @@
+/*
+ * C fallback implementation of the Sunxi 32x32 tiled NV12 untiling,
+ * used on architectures without the NEON assembly version (tiled_yuv.S
+ * only builds on 32-bit ARM).
+ */
+
+#ifdef __aarch64__
+
+#include <stdint.h>
+#include <string.h>
+
+#include "tiled_yuv.h"
+
+void tiled_to_planar(void *src, void *dst, unsigned int dst_pitch,
+		     unsigned int width, unsigned int height)
+{
+	unsigned int tiles_per_row = (width + 31) / 32;
+	unsigned int i, j;
+
+	for (i = 0; i < height; i++) {
+		for (j = 0; j < width; j += 32) {
+			unsigned int tile = (i / 32) * tiles_per_row + (j / 32);
+			unsigned int offset = tile * 32 * 32 + (i % 32) * 32;
+			unsigned int length = (width - j) < 32 ? (width - j) : 32;
+
+			memcpy((uint8_t *)dst + i * dst_pitch + j,
+			       (uint8_t *)src + offset, length);
+		}
+	}
+}
+
+#endif

--- a/src/tiled_yuv.h
+++ b/src/tiled_yuv.h
@@ -27,4 +27,8 @@ void tiled_deinterleave_to_planar(void *src, void *dst1, void *dst2,
 				  unsigned int dst_pitch, unsigned int width,
 				  unsigned int height);
 
+void sand_to_planar(void *src, void *dst, unsigned int dst_pitch,
+		    unsigned int col_stride, unsigned int width,
+		    unsigned int height);
+
 #endif

--- a/src/v4l2.c
+++ b/src/v4l2.c
@@ -169,6 +169,13 @@ int v4l2_set_format(int video_fd, unsigned int type, unsigned int pixelformat,
 		return -1;
 	}
 
+	request_log("DEBUG s_fmt type=%u fourcc=%.4s %ux%u -> %ux%u\n", type,
+		    (char *)&pixelformat, width, height,
+		    v4l2_type_is_mplane(type) ? format.fmt.pix_mp.width :
+						format.fmt.pix.width,
+		    v4l2_type_is_mplane(type) ? format.fmt.pix_mp.height :
+						format.fmt.pix.height);
+
 	return 0;
 }
 
@@ -259,6 +266,9 @@ int v4l2_create_buffers(int video_fd, unsigned int type,
 			    strerror(errno));
 		return -1;
 	}
+
+	request_log("DEBUG create_bufs type=%u requested=%u created=%u index=%u\n",
+		    type, buffers_count, buffers.count, buffers.index);
 
 	if (index_base != NULL)
 		*index_base = buffers.index;
@@ -397,6 +407,12 @@ int v4l2_dequeue_buffer(int video_fd, int request_fd, unsigned int type,
 		return -1;
 	}
 
+	request_log("DEBUG dqbuf type=%u index=%u flags=0x%x bytesused=%u%s\n",
+		    type, buffer.index, buffer.flags,
+		    v4l2_type_is_mplane(type) ? planes[0].bytesused :
+						buffer.bytesused,
+		    (buffer.flags & V4L2_BUF_FLAG_ERROR) ? " (ERROR)" : "");
+
 	return 0;
 }
 
@@ -467,10 +483,12 @@ int v4l2_set_stream(int video_fd, unsigned int type, bool enable)
 	rc = ioctl(video_fd, enable ? VIDIOC_STREAMON : VIDIOC_STREAMOFF,
 		   &buf_type);
 	if (rc < 0) {
-		request_log("Unable to %sable stream: %s\n",
-			    enable ? "en" : "dis", strerror(errno));
+		request_log("Unable to %sable stream for type %u: %s\n",
+			    enable ? "en" : "dis", type, strerror(errno));
 		return -1;
 	}
+
+	request_log("DEBUG stream%s type=%u\n", enable ? "on" : "off", type);
 
 	return 0;
 }

--- a/src/v4l2.c
+++ b/src/v4l2.c
@@ -413,6 +413,12 @@ int v4l2_dequeue_buffer(int video_fd, int request_fd, unsigned int type,
 						buffer.bytesused,
 		    (buffer.flags & V4L2_BUF_FLAG_ERROR) ? " (ERROR)" : "");
 
+	if (buffer.flags & V4L2_BUF_FLAG_ERROR) {
+		request_log("Dequeued buffer %u (type %u) with error flag\n",
+			    buffer.index, type);
+		return -1;
+	}
+
 	return 0;
 }
 

--- a/src/video.c
+++ b/src/video.c
@@ -55,6 +55,16 @@ static struct video_format formats[] = {
 		.planes_count		= 2,
 		.bpp			= 16
 	},
+	{
+		.description		= "Broadcom SAND128 column-tiled NV12 YUV",
+		.v4l2_format		= V4L2_PIX_FMT_NV12M_COL128,
+		.v4l2_buffers_count	= 2,
+		.v4l2_mplane		= true,
+		.drm_format		= DRM_FORMAT_NV12,
+		.drm_modifier		= DRM_FORMAT_MOD_BROADCOM_SAND128,
+		.planes_count		= 2,
+		.bpp			= 16
+	},
 };
 
 static unsigned int formats_count = sizeof(formats) / sizeof(formats[0]);

--- a/src/video.h
+++ b/src/video.h
@@ -26,6 +26,17 @@
 #define _VIDEO_H_
 
 #include <stdbool.h>
+#include <stdint.h>
+
+#include <linux/videodev2.h>
+
+/*
+ * Raspberry Pi downstream pixel format: NV12 in 128-byte wide columns
+ * (SAND128), two-planar variant. Not present in mainline uapi headers.
+ */
+#ifndef V4L2_PIX_FMT_NV12M_COL128
+#define V4L2_PIX_FMT_NV12M_COL128 v4l2_fourcc('N', 'c', '1', '2')
+#endif
 
 struct video_format {
 	char *description;


### PR DESCRIPTION
This pull request introduces significant changes to support the Linux kernel 6.x stateless codec API, modernizes the codebase to use upstream V4L2 control headers, and improves H.264 decoding reliability and compatibility. Key updates include a new documentation addendum for kernel 6.x, replacement of custom control headers with standard kernel headers, refactoring to use stateless V4L2 controls, and several fixes to the H.264 decoding pipeline.

**Kernel 6.x port and documentation:**

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76-R193): Added a comprehensive addendum describing the port to the kernel 6.x stateless codec API, usage instructions, supported hardware, limitations, and verification methods.

**Modernization: Upstream V4L2 control headers:**

* `src/config.c`, `src/context.c`, `src/h264.c`, `src/h265.c`: Replaced custom codec control headers (e.g., `h264-ctrls.h`, `hevc-ctrls.h`) with the upstream `<linux/v4l2-controls.h>`, aligning with kernel 6.x and reducing maintenance burden. [[1]](diffhunk://#diff-18680f57f5d32607a3b196afffe0d6ecb250af6c0a994b304b88fc91231250bfL37-R37) [[2]](diffhunk://#diff-ef1c7e09360fca411b599799813ab8c5ff247da475d40c7f0000fd5a72f880ceL42-R42) [[3]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL36-R36) [[4]](diffhunk://#diff-ade16bbe522b3e3dd6b541ce8f1b6c515b785a1069283cb848396d4d5c1e3da8L39-R39)
* `include/h264-ctrls.h`, `include/hevc-ctrls.h`: Added guards to avoid conflicts with upstream kernel headers. [[1]](diffhunk://#diff-e69bf35089fc4c21717d60a3ee7b8014d3e6c9ece1822ccdcae7399fe422434aR14-R15) [[2]](diffhunk://#diff-e69bf35089fc4c21717d60a3ee7b8014d3e6c9ece1822ccdcae7399fe422434aR200) [[3]](diffhunk://#diff-4e46eb31712fdc91390b96b1e57d44361a2290e58ebaf1539a87efee8061409bR10-R11) [[4]](diffhunk://#diff-4e46eb31712fdc91390b96b1e57d44361a2290e58ebaf1539a87efee8061409bR32) [[5]](diffhunk://#diff-4e46eb31712fdc91390b96b1e57d44361a2290e58ebaf1539a87efee8061409bR104-R112) [[6]](diffhunk://#diff-4e46eb31712fdc91390b96b1e57d44361a2290e58ebaf1539a87efee8061409bL184-R191)

**Stateless V4L2 controls and H.264 pipeline fixes:**

* [`src/h264.c`](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL436-R481): Updated to use stateless V4L2 control IDs (e.g., `V4L2_CID_STATELESS_H264_*`) instead of legacy MPEG controls, and split slice prediction weights into a dedicated control as required by the stateless API.
* [`src/h264.c`](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fR199-R201): Fixed and improved H.264 DPB and slice parameter handling, including proper filling of reference fields, passing of scaling matrix flags, and correct mapping of picture parameters. [[1]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fR199-R201) [[2]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL223-R235) [[3]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fR267-R269) [[4]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fR278) [[5]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL330-L332) [[6]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL359-R373) [[7]](diffhunk://#diff-46fd38d7308b83de3859d47de4ba7b884470e9ca8a5d387843fee227a3a6dd0fL378-R413)

**Profile detection and context creation improvements:**

* `src/config.c`, `src/context.c`: Improved detection of supported profiles and pixel formats, including support for single- and multi-planar output queues, and switched to the correct H.264 slice format (`V4L2_PIX_FMT_H264_SLICE`). [[1]](diffhunk://#diff-18680f57f5d32607a3b196afffe0d6ecb250af6c0a994b304b88fc91231250bfR121-R123) [[2]](diffhunk://#diff-18680f57f5d32607a3b196afffe0d6ecb250af6c0a994b304b88fc91231250bfL131-R135) [[3]](diffhunk://#diff-18680f57f5d32607a3b196afffe0d6ecb250af6c0a994b304b88fc91231250bfR146-R148) [[4]](diffhunk://#diff-ef1c7e09360fca411b599799813ab8c5ff247da475d40c7f0000fd5a72f880ceL107-R105)
* `src/context.c`, `src/context.h`: Ensured a buffer pool is always created for the output queue, even when no surfaces are provided at context creation, improving compatibility with modern libva clients. [[1]](diffhunk://#diff-ef1c7e09360fca411b599799813ab8c5ff247da475d40c7f0000fd5a72f880ceR124-R143) [[2]](diffhunk://#diff-0b11759ffdecd88f727e460c2490c86bce5dfe0ee92f8df9dab0d37d57d235ffR47-R55)

These changes collectively bring the codebase up to date with the latest Linux stateless video decoding APIs, improve hardware compatibility, and enhance robustness for modern VA-API clients.